### PR TITLE
Remove installation of workbench_operators headers

### DIFF
--- a/dynamixel_workbench_operators/CMakeLists.txt
+++ b/dynamixel_workbench_operators/CMakeLists.txt
@@ -61,10 +61,6 @@ install(TARGETS wheel_operator
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
 ################################################################################
 # Test
 ################################################################################


### PR DESCRIPTION
The CMakeLists.txt in dynamixel_workbench_operators refered to the
installation of header files. However, there are no header files in the
package, so the installation step halts. I removed the install target.