### PR TITLE
[kinetic][CI] Add Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: USE_DEB=true  ROS_DISTRO="kinetic"   PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - .ci_config/travis.sh
+


### PR DESCRIPTION
You guys really need to employ Continuous Integration to avoid buildfarm hassles ;)!

[ROS offers ways](http://wiki.ros.org/CIs) to simplify the usage of CI. In this PR, I'm suggesting to use [industrial_ci](http://wiki.ros.org/industrial_ci). It is a set of scripts for CI on ROS. The simple config file in this PR enables CI to run on Travis CI for this repo, including [ROS pre-release test](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest) that is recommended for released packages.
Contrary to its name it works for non-industrial ROS packages as well, btw.

If this looks good, can any admin enable Travis for this repo at https://travis-ci.org/profile/ROBOTIS-GIT?

----

I've run CI jobs on my fork against current HEAD, then found the same error as reported in https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/77

pre-release test https://travis-ci.org/130s/dynamixel-workbench/jobs/294282260#L4718
```
Makefile:61: recipe for target 'install' failed
```

In addition, some errors during build is caught:
https://travis-ci.org/130s/dynamixel-workbench/jobs/294282258#L663
```
Starting  >>> dynamixel_workbench_operators                        
Starting  >>> dynamixel_workbench_toolbox                          
_______________________________________________________________________________
Errors     << dynamixel_workbench_operators:make /root/catkin_ws/logs/dynamixel_workbench_operators/build.make.000.log
/root/catkin_ws/src/dynamixel-workbench/dynamixel_workbench_operators/src/joint_operator.cpp:20:51: fatal error: dynamixel_workbench_msgs/JointCommand.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/joint_operator.dir/src/joint_operator.cpp.o] Error 1
make[1]: *** [CMakeFiles/joint_operator.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/root/catkin_ws/src/dynamixel-workbench/dynamixel_workbench_operators/src/wheel_operator.cpp:23:51: fatal error: dynamixel_workbench_msgs/WheelCommand.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/wheel_operator.dir/src/wheel_operator.cpp.o] Error 1
make[1]: *** [CMakeFiles/wheel_operator.dir/all] Error 2
make: *** [all] Error 2
cd /root/catkin_ws/build/dynamixel_workbench_operators; catkin build --get-env dynamixel_workbench_operators | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
...............................................................................
Failed     << dynamixel_workbench_operators:make                    [ Exited with code 2 ]
Failed    <<< dynamixel_workbench_operators                        m [ 9.0 seconds ]
Abandoned <<< dynamixel_workbench_controllers                       [ Unrelated job failed ]
Abandoned <<< dynamixel_workbench_single_manager                    [ Unrelated job failed ]
Abandoned <<< dynamixel_workbench_single_manager_gui                [ Unrelated job failed ]
Finished  <<< dynamixel_workbench_toolbox   
```
