### PR TITLE
Dynamixel Workbench: tiem_names on OpenCM/OpenCR same as others

### DIFF
--- a/dynamixel_workbench_single_manager/src/single_dynamixel_monitor.cpp
+++ b/dynamixel_workbench_single_manager/src/single_dynamixel_monitor.cpp
@@ -201,7 +201,7 @@ bool SingleDynamixelMonitor::showDynamixelControlTable(void)
   bool comm_result = false;
   int32_t torque_status = 0;
   uint16_t torque_enable_address = 0;
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
 
   for (int item_num = 0; item_num < dynamixel_driver_->getTheNumberOfItem(dxl_id_); item_num++)
   {
@@ -231,7 +231,7 @@ bool SingleDynamixelMonitor::showDynamixelControlTable(void)
 
 bool SingleDynamixelMonitor::checkValidationCommand(std::string cmd)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
 
   for (int item_num = 0; item_num < dynamixel_driver_->getTheNumberOfItem(dxl_id_); item_num++)
   {
@@ -617,7 +617,7 @@ void SingleDynamixelMonitor::dynamixelStatePublish(void)
 
 void SingleDynamixelMonitor::AX(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::AX ax_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -722,7 +722,7 @@ void SingleDynamixelMonitor::AX(void)
 
 void SingleDynamixelMonitor::RX(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::RX rx_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -827,7 +827,7 @@ void SingleDynamixelMonitor::RX(void)
 
 void SingleDynamixelMonitor::MX(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::MX mx_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -936,7 +936,7 @@ void SingleDynamixelMonitor::MX(void)
 
 void SingleDynamixelMonitor::MXExt(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::MXExt mxext_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1051,7 +1051,7 @@ void SingleDynamixelMonitor::MXExt(void)
 
 void SingleDynamixelMonitor::MX2(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::MX2 mx2_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1190,7 +1190,7 @@ void SingleDynamixelMonitor::MX2(void)
 
 void SingleDynamixelMonitor::MX2Ext(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::MX2Ext mx2ext_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1333,7 +1333,7 @@ void SingleDynamixelMonitor::MX2Ext(void)
 
 void SingleDynamixelMonitor::EX(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::EX ex_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1442,7 +1442,7 @@ void SingleDynamixelMonitor::EX(void)
 
 void SingleDynamixelMonitor::XL320(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::XL320 xl320_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1543,7 +1543,7 @@ void SingleDynamixelMonitor::XL320(void)
 
 void SingleDynamixelMonitor::XL(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::XL xl_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1682,7 +1682,7 @@ void SingleDynamixelMonitor::XL(void)
 
 void SingleDynamixelMonitor::XM(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::XM xm_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1825,7 +1825,7 @@ void SingleDynamixelMonitor::XM(void)
 
 void SingleDynamixelMonitor::XMExt(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::XMExt xmext_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -1974,7 +1974,7 @@ void SingleDynamixelMonitor::XMExt(void)
 
 void SingleDynamixelMonitor::XH(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::XH xh_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -2117,7 +2117,7 @@ void SingleDynamixelMonitor::XH(void)
 
 void SingleDynamixelMonitor::PRO(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::PRO pro_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;
@@ -2238,7 +2238,7 @@ void SingleDynamixelMonitor::PRO(void)
 
 void SingleDynamixelMonitor::PROExt(void)
 {
-  ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
+  const ControlTableItem* item_ptr = dynamixel_driver_->getControlItemPtr(dxl_id_);
   dynamixel_workbench_msgs::PROExt proext_state;
 
   uint16_t last_register_addr = item_ptr[dynamixel_driver_->getTheNumberOfItem(dxl_id_)-1].address;

--- a/dynamixel_workbench_single_manager_gui/src/main_window.cpp
+++ b/dynamixel_workbench_single_manager_gui/src/main_window.cpp
@@ -398,7 +398,7 @@ void MainWindow::setAddressComboBox(bool torque_enable)
   }
 
   uint16_t torque_enable_address = 0;
-  ControlTableItem* item_ptr = dynamixel_tool_->getControlItemPtr();
+  const ControlTableItem* item_ptr = dynamixel_tool_->getControlItemPtr();
 
   for (int item_num = 0; item_num < dynamixel_tool_->getTheNumberOfItem(); item_num++)
   {

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/control_table_item.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/control_table_item.h
@@ -23,8 +23,9 @@
 
 typedef struct 
 {
-  uint16_t    address;
   const char* item_name;
+  uint16_t    address;
+  uint8_t	  item_name_length;
   uint8_t     data_length;
 } ControlTableItem;
 

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_driver.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_driver.h
@@ -39,13 +39,13 @@
 
 typedef struct 
 {
-  ControlTableItem *cti; 
+  const ControlTableItem *cti; 
   dynamixel::GroupSyncWrite *groupSyncWrite;    
 } SyncWriteHandler;
 
 typedef struct 
 {
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   dynamixel::GroupSyncRead  *groupSyncRead;     
 } SyncReadHandler;
 
@@ -84,7 +84,7 @@ class DynamixelDriver
   int getBaudrate(void);
   char* getModelName(uint8_t id);
   uint16_t getModelNum(uint8_t id);
-  ControlTableItem* getControlItemPtr(uint8_t id);
+  const ControlTableItem* getControlItemPtr(uint8_t id);
   uint8_t getTheNumberOfItem(uint8_t id);
 
   bool scan(uint8_t *get_id, uint8_t *get_id_num, uint8_t range = 200);

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_item.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_item.h
@@ -81,7 +81,7 @@ typedef struct
 } ModelInfo;
 
 uint8_t getTheNumberOfControlItem();
-ControlTableItem* getConrolTableItem(uint16_t model_number);
+const ControlTableItem* getConrolTableItem(uint16_t model_number);
 ModelInfo* getModelInfo(uint16_t model_number);
 
 #endif //DYNAMIXEL_H

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
@@ -23,12 +23,6 @@
 
 #include "dynamixel_item.h"
 
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  #define ITEM_ARRAY_SIZE 14
-#else
-  #define ITEM_ARRAY_SIZE 60
-#endif
-
 typedef struct
 {
   char model_name[20];
@@ -43,14 +37,8 @@ class DynamixelTool
   uint8_t dxl_info_cnt_;
 
  private:
-  ControlTableItem* item_ptr_;
+  const ControlTableItem* item_ptr_;
   ModelInfo* info_ptr_;
-
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  ControlTableItem item_[ITEM_ARRAY_SIZE];
-#else
-  ControlTableItem item_[ITEM_ARRAY_SIZE];
-#endif
 
   ModelInfo info_;
   uint8_t the_number_of_item_;
@@ -76,8 +64,8 @@ class DynamixelTool
   float getMaxRadian(void);
 
   uint8_t getTheNumberOfItem(void);
-  ControlTableItem* getControlItem(const char *item_name);
-  ControlTableItem* getControlItemPtr(void);
+  const ControlTableItem* getControlItem(const char *item_name);
+  const ControlTableItem* getControlItemPtr(void);
   ModelInfo* getModelInfoPtr(void);
 
  private:

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
@@ -102,6 +102,11 @@ class DynamixelWorkbench
   int16_t convertTorque2Value(uint8_t id, float torque);
   float convertValue2Torque(uint8_t id, int16_t value);
 
+  const ControlTableItem* getControlItemPtr(uint8_t id);
+  uint8_t getControlItemCount(uint8_t id);
+
+
+
  private:
   void millis(uint16_t msec);
 

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -151,6 +151,7 @@ char *DynamixelDriver::getModelName(uint8_t id)
     if (tools_[factor].dxl_info_[i].id == id)
       return tools_[factor].dxl_info_[i].model_name;
   }
+  return NULL;
 }
 
 uint16_t DynamixelDriver::getModelNum(uint8_t id)
@@ -162,9 +163,10 @@ uint16_t DynamixelDriver::getModelNum(uint8_t id)
     if (tools_[factor].dxl_info_[i].id == id)
       return tools_[factor].dxl_info_[i].model_num;
   }
+  return 0;
 }
 
-ControlTableItem* DynamixelDriver::getControlItemPtr(uint8_t id)
+const ControlTableItem* DynamixelDriver::getControlItemPtr(uint8_t id)
 {
   uint8_t factor = getToolsFactor(id);
 
@@ -398,6 +400,7 @@ bool DynamixelDriver::reset(uint8_t id)
       return false;
     }
   }
+  return false;  // should never get here.
 }
 
 bool DynamixelDriver::writeRegister(uint8_t id, const char *item_name, int32_t data)
@@ -405,8 +408,13 @@ bool DynamixelDriver::writeRegister(uint8_t id, const char *item_name, int32_t d
   uint8_t error = 0;
   int dxl_comm_result = COMM_TX_FAIL;
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   if (cti->data_length == BYTE)
   {
@@ -478,9 +486,13 @@ bool DynamixelDriver::readRegister(uint8_t id, const char *item_name, int32_t *d
   int16_t value_16_bit = 0;
   int32_t value_32_bit = 0;
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
-
+  if (cti == NULL)
+  {
+    return false;
+  }
+  
   if (cti->data_length == BYTE)
   {
     dxl_comm_result = packetHandler_->read1ByteTxRx(portHandler_, id, cti->address, (uint8_t *)&value_8_bit, &error);
@@ -606,6 +618,7 @@ uint8_t DynamixelDriver::getToolsFactor(uint8_t id)
       }
     }
   }
+  return 0;   // BUGBUG:: Not sure what a good last resort value is
 }
 
 const char *DynamixelDriver::findModelName(uint16_t model_num)
@@ -698,8 +711,13 @@ const char *DynamixelDriver::findModelName(uint16_t model_num)
 
 void DynamixelDriver::addSyncWrite(const char *item_name)
 {
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[0].getControlItem(item_name);
+
+  if (cti == NULL)
+  {
+    return;
+  }
 
   syncWriteHandler_[sync_write_handler_cnt_].cti = cti;
 
@@ -718,13 +736,21 @@ bool DynamixelDriver::syncWrite(const char *item_name, int32_t *data)
   uint8_t cnt = 0;
 
   SyncWriteHandler swh;
+  bool swh_found = false;
 
   for (int index = 0; index < sync_write_handler_cnt_; index++)
   {
     if (!strncmp(syncWriteHandler_[index].cti->item_name, item_name, strlen(item_name)))
     {
       swh = syncWriteHandler_[index];
+      swh_found = true;
+      break;
     }
+  }
+
+  if (!swh_found)
+  {
+    return false;
   }
 
   for (int i = 0; i < tools_cnt_; i++)
@@ -764,15 +790,23 @@ bool DynamixelDriver::syncWrite(uint8_t *id, uint8_t id_num, const char *item_na
   uint8_t cnt = 0;
 
   SyncWriteHandler swh;
+  bool swh_found = false;
 
   for (int index = 0; index < sync_write_handler_cnt_; index++)
   {
     if (!strncmp(syncWriteHandler_[index].cti->item_name, item_name, strlen(item_name)))
     {
       swh = syncWriteHandler_[index];
+      swh_found = true;
+      break;
     }
   }
 
+  if (!swh_found)
+  {
+    return false;
+  }
+  
   for (int i = 0; i < id_num; i++)
   {
     data_byte[0] = DXL_LOBYTE(DXL_LOWORD(data[cnt]));
@@ -785,6 +819,7 @@ bool DynamixelDriver::syncWrite(uint8_t *id, uint8_t id_num, const char *item_na
     {
       return false;
     }
+    cnt++;
   }
 
   dxl_comm_result = swh.groupSyncWrite->txPacket();
@@ -798,9 +833,13 @@ bool DynamixelDriver::syncWrite(uint8_t *id, uint8_t id_num, const char *item_na
 
 void DynamixelDriver::addSyncRead(const char *item_name)
 {
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[0].getControlItem(item_name);
 
+  if (cti == NULL)
+  {
+    return;
+  }
   syncReadHandler_[sync_read_handler_cnt_].cti = cti;
   
   syncReadHandler_[sync_read_handler_cnt_++].groupSyncRead = new dynamixel::GroupSyncRead(portHandler_,
@@ -818,15 +857,21 @@ bool DynamixelDriver::syncRead(const char *item_name, int32_t *data)
   int index = 0;
 
   SyncReadHandler srh;
+  bool srh_found = false;
   
   for (int index = 0; index < sync_read_handler_cnt_; index++)
   {
     if (!strncmp(syncReadHandler_[index].cti->item_name, item_name, strlen(item_name)))
     {
       srh = syncReadHandler_[index];
+      srh_found = true;
+      break; // Found it, don't need to continue search
     }
   }
-
+  if (!srh_found)
+  {
+    return false; // did not find item_name in list
+  }
   for (int i = 0; i < tools_cnt_; i++)
   {
     for (int j = 0; j < tools_[i].dxl_info_cnt_; j++)
@@ -876,8 +921,12 @@ bool DynamixelDriver::addBulkWriteParam(uint8_t id, const char *item_name, int32
   bool dxl_addparam_result = false;
   uint8_t data_byte[4] = {0, };
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   data_byte[0] = DXL_LOBYTE(DXL_LOWORD(data));
   data_byte[1] = DXL_HIBYTE(DXL_LOWORD(data));
@@ -917,8 +966,12 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, const char *item_name)
 {
   bool dxl_addparam_result = false;
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   dxl_addparam_result = groupBulkRead_->addParam(id, cti->address, cti->data_length);
   if (dxl_addparam_result != true)
@@ -945,8 +998,12 @@ bool DynamixelDriver::sendBulkReadPacket()
 bool DynamixelDriver::bulkRead(uint8_t id, const char *item_name, int32_t *data)
 {
   bool dxl_getdata_result = false;
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   dxl_getdata_result = groupBulkRead_->isAvailable(id, cti->address, cti->data_length);
   if (dxl_getdata_result != true)

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
@@ -20,71 +20,143 @@
 
 static uint8_t the_number_of_item = 0;
 
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-static ControlTableItem item[15]  = {0, };
-#else
-static ControlTableItem item[60]  = {0, };
-#endif
 
-static ModelInfo model_info = {0.0, };
+static ModelInfo model_info = {0.0, 0.0, 0, 0, 0, 0.0, 0.0};
 
-static void setAXItem(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//=========================================================
+// Servo register definitions
+//=========================================================
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
+//_________________________________________________________
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
+static const char s_Acceleration_Limit[] = "Acceleration_Limit";
+static const char s_Alarm_LED[] = "Alarm_LED";
+static const char s_Baud_Rate[] = "Baud_Rate";
+static const char s_Bus_Watchdog[] = "Bus_Watchdog";
+static const char s_CCW_Angle_Limit[] = "CCW_Angle_Limit";
+static const char s_CCW_Compliance_Margin[] = "CCW_Compliance_Margin";
+static const char s_CCW_Compliance_Slope[] = "CCW_Compliance_Slope";
+static const char s_Control_Mode[] = "Control_Mode";
+static const char s_Current[] = "Current";
+static const char s_Current_Limit[] = "Current_Limit";
+static const char s_CW_Angle_Limit[] = "CW_Angle_Limit";
+static const char s_CW_Compliance_Margin[] = "CW_Compliance_Margin";
+static const char s_CW_Compliance_Slope[] = "CW_Compliance_Slope";
+static const char s_D_gain[] = "D_gain";
+static const char s_Drive_Mode[] = "Drive_Mode";
+static const char s_External_Port_Mode_1[] = "External_Port_Mode_1";
+static const char s_External_Port_Mode_2[] = "External_Port_Mode_2";
+static const char s_External_Port_Mode_3[] = "External_Port_Mode_3";
+static const char s_External_Port_Mode_4[] = "External_Port_Mode_4";
+static const char s_Feedforward_1st_Gain[] = "Feedforward_1st_Gain";
+static const char s_Feedforward_2nd_Gain[] = "Feedforward_2nd_Gain";
+static const char s_Firmware_Version[] = "Firmware_Version";
+static const char s_Goal_Acceleration[] = "Goal_Acceleration";
+static const char s_Goal_Current[] = "Goal_Current";
+static const char s_Goal_Position[] = "Goal_Position";
+static const char s_Goal_PWM[] = "Goal_PWM";
+static const char s_Goal_Torque[] = "Goal_Torque";
+static const char s_Goal_Velocity[] = "Goal_Velocity";
+static const char s_Hardware_Error_Status[] = "Hardware_Error_Status";
+static const char s_Homing_Offset[] = "Homing_Offset";
+static const char s_I_gain[] = "I_gain";
+static const char s_ID[] = "ID";
+static const char s_LED[] = "LED";
+static const char s_LED_BLUE[] = "LED_BLUE";
+static const char s_LED_GREEN[] = "LED_GREEN";
+static const char s_LED_RED[] = "LED_RED";
+static const char s_Lock[] = "Lock";
+static const char s_Max_Position_Limit[] = "Max_Position_Limit";
+static const char s_Max_Torque[] = "Max_Torque";
+static const char s_Max_Voltage_Limit[] = "Max_Voltage_Limit";
+static const char s_Min_Position_Limit[] = "Min_Position_Limit";
+static const char s_Min_Voltage_Limit[] = "Min_Voltage_Limit";
+static const char s_Model_Number[] = "Model_Number";
+static const char s_Moving[] = "Moving";
+static const char s_Moving_Speed[] = "Moving_Speed";
+static const char s_Moving_Status[] = "Moving_Status";
+static const char s_Moving_Threshold[] = "Moving_Threshold";
+static const char s_Multi_Turn_Offset[] = "Multi_Turn_Offset";
+static const char s_Operating_Mode[] = "Operating_Mode";
+static const char s_P_gain[] = "P_gain";
+static const char s_Position_D_Gain[] = "Position_D_Gain";
+static const char s_Position_I_Gain[] = "Position_I_Gain";
+static const char s_Position_P_Gain[] = "Position_P_Gain";
+static const char s_Position_Trajectory[] = "Position_Trajectory";
+static const char s_Present_Current[] = "Present_Current";
+static const char s_Present_Input[] = "Present_Input"; 
+static const char s_Present_Input_Voltage[] = "Present_Input_Voltage";
+static const char s_Present_Load[] = "Present_Load";
+static const char s_Present_Position[] = "Present_Position";
+static const char s_Present_PWM[] = "Present_PWM";
+static const char s_Present_Speed[] = "Present_Speed";
+static const char s_Present_Temperature[] = "Present_Temperature";
+static const char s_Present_Velocity[] = "Present_Velocity";
+static const char s_Present_Voltage[] = "Present_Voltage";
+static const char s_Profile_Acceleration[] = "Profile_Acceleration";
+static const char s_Profile_Velocity[] = "Profile_Velocity";
+static const char s_Protocol_Version[] = "Protocol_Version";
+static const char s_Punch[] = "Punch";
+static const char s_PWM_Limit[] = "PWM_Limit";
+static const char s_Realtime_Tick[] = "Realtime_Tick";
+static const char s_Registered[] = "Registered";
+static const char s_Registered_Instruction[] = "Registered_Instruction";
+static const char s_Resolution_Divider[] = "Resolution_Divider";
+static const char s_Return_Delay_Time[] = "Return_Delay_Time";
+static const char s_Secondary_ID[] = "Secondary_ID";
+static const char s_Sensored_Current[] = "Sensored_Current";
+static const char s_Shutdown[] = "Shutdown";
+static const char s_Status_Return_Level[] = "Status_Return_Level";
+static const char s_Temperature_Limit[] = "Temperature_Limit";
+static const char s_Torque_Control_Mode_Enable[] = "Torque_Control_Mode_Enable";
+static const char s_Torque_Enable[] = "Torque_Enable";
+static const char s_Torque_Limit[] = "Torque_Limit";
+static const char s_Velocity_I_Gain[] = "Velocity_I_Gain";
+static const char s_Velocity_Limit[] = "Velocity_Limit";
+static const char s_Velocity_P_Gain[] = "Velocity_P_Gain";
+static const char s_Velocity_Trajectory[] = "Velocity_Trajectory";
 
-  item[14] = {24 , "Torque_Enable"                 , 1};
-  item[15] = {25 , "LED"                           , 1};
-  item[16] = {26 , "CW_Compliance_Margin"          , 1};
-  item[17] = {27 , "CCW_Compliance_Margin"         , 1};
-  item[18] = {28 , "CW_Compliance_Slope"           , 1};
-  item[19] = {29 , "CCW_Compliance_Slope"          , 1};
-  item[20] = {30 , "Goal_Position"                 , 2};
-  item[21] = {32 , "Moving_Speed"                  , 2};
-  item[22] = {34 , "Torque_Limit"                  , 2};
-  item[23] = {36 , "Present_Position"              , 2};
-  item[24] = {38 , "Present_Speed"                 , 2};
-  item[25] = {40 , "Present_Load"                  , 2};
-  item[26] = {42 , "Present_Voltage"               , 1};
-  item[27] = {43 , "Present_Temperature"           , 1};
-  item[28] = {44 , "Registered"                    , 1};
-  item[29] = {46 , "Moving"                        , 1};
-  item[30] = {47 , "Lock"                          , 1};
-  item[31] = {48 , "Punch"                         , 2};
 
-  the_number_of_item = 32;
-#endif  
-}
+//_________________________________________________________
+
+//---------------------------------------------------------
+// AX servos - (num == AX_12A || num == AX_12W || num == AX_18A)
+//---------------------------------------------------------
+static const ControlTableItem items_AX[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 2,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 3,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 4,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 5,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_CW_Angle_Limit, 6,  sizeof(s_CW_Angle_Limit)-1, 2},
+    {s_CCW_Angle_Limit, 8,  sizeof(s_CCW_Angle_Limit)-1, 2},
+    {s_Temperature_Limit, 11,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Min_Voltage_Limit, 12,  sizeof(s_Min_Voltage_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 13,  sizeof(s_Max_Voltage_Limit)-1, 1},
+    {s_Max_Torque, 14,  sizeof(s_Max_Torque)-1, 2},
+    {s_Status_Return_Level, 16,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Alarm_LED, 17,  sizeof(s_Alarm_LED)-1, 1},
+    {s_Shutdown, 18,  sizeof(s_Shutdown)-1, 1},
+
+    {s_Torque_Enable, 24,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 25,  sizeof(s_LED)-1, 1},
+    {s_CW_Compliance_Margin, 26,  sizeof(s_CW_Compliance_Margin)-1, 1},
+    {s_CCW_Compliance_Margin, 27,  sizeof(s_CCW_Compliance_Margin)-1, 1},
+    {s_CW_Compliance_Slope, 28,  sizeof(s_CW_Compliance_Slope)-1, 1},
+    {s_CCW_Compliance_Slope, 29,  sizeof(s_CCW_Compliance_Slope)-1, 1},
+    {s_Goal_Position, 30,  sizeof(s_Goal_Position)-1, 2},
+    {s_Moving_Speed, 32,  sizeof(s_Moving_Speed)-1, 2},
+    {s_Torque_Limit, 34,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Present_Position, 36,  sizeof(s_Present_Position)-1, 2},
+    {s_Present_Speed, 38,  sizeof(s_Present_Speed)-1, 2},
+    {s_Present_Load, 40,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Voltage, 42,  sizeof(s_Present_Voltage)-1, 1},
+    {s_Present_Temperature, 43,  sizeof(s_Present_Temperature)-1, 1},
+    {s_Registered, 44,  sizeof(s_Registered)-1, 1},
+    {s_Moving, 46,  sizeof(s_Moving)-1, 1},
+    {s_Lock, 47,  sizeof(s_Lock)-1, 1},
+    {s_Punch, 48,  sizeof(s_Punch)-1, 2} };
+#define COUNT_AX_ITEMS (sizeof(items_AX)/sizeof(items_AX[0]))
 
 static void setAXInfo()
 {
@@ -98,63 +170,45 @@ static void setAXInfo()
   model_info.max_radian                      =  2.61799;
 }
 
-static void setRXItem()
-{
-  #if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//---------------------------------------------------------
+// RX servos - (num == RX_10 || num == RX_24F || num == RX_28 || num == RX_64)
+//---------------------------------------------------------
+static const ControlTableItem items_RX[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 2,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 3,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 4,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 5,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_CW_Angle_Limit, 6,  sizeof(s_CW_Angle_Limit)-1, 2},
+    {s_CCW_Angle_Limit, 8,  sizeof(s_CCW_Angle_Limit)-1, 2},
+    {s_Temperature_Limit, 11,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Min_Voltage_Limit, 12,  sizeof(s_Min_Voltage_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 13,  sizeof(s_Max_Voltage_Limit)-1, 1},
+    {s_Max_Torque, 14,  sizeof(s_Max_Torque)-1, 2},
+    {s_Status_Return_Level, 16,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Alarm_LED, 17,  sizeof(s_Alarm_LED)-1, 1},
+    {s_Shutdown, 18,  sizeof(s_Shutdown)-1, 1},
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
+    {s_Torque_Enable, 24,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 25,  sizeof(s_LED)-1, 1},
+    {s_CW_Compliance_Margin, 26,  sizeof(s_CW_Compliance_Margin)-1, 1},
+    {s_CCW_Compliance_Margin, 27,  sizeof(s_CCW_Compliance_Margin)-1, 1},
+    {s_CW_Compliance_Slope, 28,  sizeof(s_CW_Compliance_Slope)-1, 1},
+    {s_CCW_Compliance_Slope, 29,  sizeof(s_CCW_Compliance_Slope)-1, 1},
+    {s_Goal_Position, 30,  sizeof(s_Goal_Position)-1, 2},
+    {s_Moving_Speed, 32,  sizeof(s_Moving_Speed)-1, 2},
+    {s_Torque_Limit, 34,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Present_Position, 36,  sizeof(s_Present_Position)-1, 2},
+    {s_Present_Speed, 38,  sizeof(s_Present_Speed)-1, 2},
+    {s_Present_Load, 40,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Voltage, 42,  sizeof(s_Present_Voltage)-1, 1},
+    {s_Present_Temperature, 43,  sizeof(s_Present_Temperature)-1, 1},
+    {s_Registered, 44,  sizeof(s_Registered)-1, 1},
+    {s_Moving, 46,  sizeof(s_Moving)-1, 1},
+    {s_Lock, 47,  sizeof(s_Lock)-1, 1},
+    {s_Punch, 48,  sizeof(s_Punch)-1, 2} };
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-
-  item[14] = {24 , "Torque_Enable"                 , 1};
-  item[15] = {25 , "LED"                           , 1};
-  item[16] = {26 , "CW_Compliance_Margin"          , 1};
-  item[17] = {27 , "CCW_Compliance_Margin"         , 1};
-  item[18] = {28 , "CW_Compliance_Slope"           , 1};
-  item[19] = {29 , "CCW_Compliance_Slope"          , 1};
-  item[20] = {30 , "Goal_Position"                 , 2};
-  item[21] = {32 , "Moving_Speed"                  , 2};
-  item[22] = {34 , "Torque_Limit"                  , 2};
-  item[23] = {36 , "Present_Position"              , 2};
-  item[24] = {38 , "Present_Speed"                 , 2};
-  item[25] = {40 , "Present_Load"                  , 2};
-  item[26] = {42 , "Present_Voltage"               , 1};
-  item[27] = {43 , "Present_Temperature"           , 1};
-  item[28] = {44 , "Registered"                    , 1};
-  item[29] = {46 , "Moving"                        , 1};
-  item[30] = {47 , "Lock"                          , 1};
-  item[31] = {48 , "Punch"                         , 2};
-
-  the_number_of_item = 32;
-#endif  
-}
+#define COUNT_RX_ITEMS (sizeof(items_RX)/sizeof(items_RX[0]))
 
 static void setRXInfo(void)
 {
@@ -168,66 +222,47 @@ static void setRXInfo(void)
   model_info.max_radian                      =  2.61799;
 }
 
-static void setEXItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW Angle_Limit"               , 2};
-  item[4]  = {10 , "Drive_Mode"                    , 1};
+//---------------------------------------------------------
+// EX servos - (num == EX_106)
+//---------------------------------------------------------
+static const ControlTableItem items_EX[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 2,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 3,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 4,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 5,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_CW_Angle_Limit, 6,  sizeof(s_CW_Angle_Limit)-1, 2},
+    {s_CCW_Angle_Limit, 8,  sizeof(s_CCW_Angle_Limit)-1, 2},
+    {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+    {s_Temperature_Limit, 11,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Min_Voltage_Limit, 12,  sizeof(s_Min_Voltage_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 13,  sizeof(s_Max_Voltage_Limit)-1, 1},
+    {s_Max_Torque, 14,  sizeof(s_Max_Torque)-1, 2},
+    {s_Status_Return_Level, 16,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Alarm_LED, 17,  sizeof(s_Alarm_LED)-1, 1},
+    {s_Shutdown, 18,  sizeof(s_Shutdown)-1, 1},
 
-  item[5]  = {24 , "Torque_Enable"                 , 1};
-  item[6]  = {25 , "LED"                           , 1};
-  item[7]  = {30 , "Goal_Position"                 , 2};
-  item[8]  = {32 , "Moving_Speed"                  , 2};
-  item[9]  = {34 , "Torque_Limit"                  , 2};
-  item[10] = {36 , "Present_Position"              , 2};
-  item[11] = {38 , "Present_Speed"                 , 2};
-  item[12] = {40 , "Present_Load"                  , 2};
-  item[13] = {46 , "Moving"                        , 1};
+    {s_Torque_Enable, 24,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 25,  sizeof(s_LED)-1, 1},
+    {s_CW_Compliance_Margin, 26,  sizeof(s_CW_Compliance_Margin)-1, 1},
+    {s_CCW_Compliance_Margin, 27,  sizeof(s_CCW_Compliance_Margin)-1, 1},
+    {s_CW_Compliance_Slope, 28,  sizeof(s_CW_Compliance_Slope)-1, 1},
+    {s_CCW_Compliance_Slope, 29,  sizeof(s_CCW_Compliance_Slope)-1, 1},
+    {s_Goal_Position, 30,  sizeof(s_Goal_Position)-1, 2},
+    {s_Moving_Speed, 34,  sizeof(s_Moving_Speed)-1, 2},
+    {s_Torque_Limit, 35,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Present_Position, 36,  sizeof(s_Present_Position)-1, 2},
+    {s_Present_Speed, 38,  sizeof(s_Present_Speed)-1, 2},
+    {s_Present_Load, 40,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Voltage, 42,  sizeof(s_Present_Voltage)-1, 1},
+    {s_Present_Temperature, 43,  sizeof(s_Present_Temperature)-1, 1},
+    {s_Registered, 44,  sizeof(s_Registered)-1, 1},
+    {s_Moving, 46,  sizeof(s_Moving)-1, 1},
+    {s_Lock, 47,  sizeof(s_Lock)-1, 1},
+    {s_Punch, 48,  sizeof(s_Punch)-1, 2},
+    {s_Sensored_Current, 56,  sizeof(s_Sensored_Current)-1, 2} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {10 , "Drive_Mode"                    , 1};
-  item[8]  = {11 , "Temperature_Limit"             , 1};
-  item[9]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[10] = {13 , "Max_Voltage_Limit"             , 1};
-  item[11] = {14 , "Max_Torque"                    , 2};
-  item[12] = {16 , "Status_Return_Level"           , 1};
-  item[13] = {17 , "Alarm_LED"                     , 1};
-  item[14] = {18 , "Shutdown"                      , 1};
-
-  item[15] = {24 , "Torque_Enable"                 , 1};
-  item[16] = {25 , "LED"                           , 1};
-  item[17] = {26 , "CW_Compliance_Margin"          , 1};
-  item[18] = {27 , "CCW_Compliance_Margin"         , 1};
-  item[19] = {28 , "CW_Compliance_Slope"           , 1};
-  item[20] = {29 , "CCW_Compliance_Slope"          , 1};
-  item[21] = {30 , "Goal_Position"                 , 2};
-  item[22] = {34 , "Moving_Speed"                  , 2};
-  item[23] = {35 , "Torque_Limit"                  , 2};
-  item[24] = {36 , "Present_Position"              , 2};
-  item[25] = {38 , "Present_Speed"                 , 2};
-  item[26] = {40 , "Present_Load"                  , 2};
-  item[27] = {42 , "Present_Voltage"               , 1};
-  item[28] = {43 , "Present_Temperature"           , 1};
-  item[29] = {44 , "Registered"                    , 1};
-  item[30] = {46 , "Moving"                        , 1};
-  item[31] = {47 , "Lock"                          , 1};
-  item[32] = {48 , "Punch"                         , 2};
-  item[33] = {56 , "Sensored_Current"              , 2};
-
-  the_number_of_item = 34;
-#endif  
-}
+#define COUNT_EX_ITEMS (sizeof(items_EX)/sizeof(items_EX[0]))
 
 static void setEXInfo()
 {
@@ -241,66 +276,47 @@ static void setEXInfo()
   model_info.max_radian                      =  2.18969008;
 }
 
-static void setMXItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//---------------------------------------------------------
+// MX Protocol 1 servos - (num == MX_12W || num == MX_28)
+//---------------------------------------------------------
+static const ControlTableItem items_MX[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 2,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 3,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 4,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 5,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_CW_Angle_Limit, 6,  sizeof(s_CW_Angle_Limit)-1, 2},
+    {s_CCW_Angle_Limit, 8,  sizeof(s_CCW_Angle_Limit)-1, 2},
+    {s_Temperature_Limit, 11,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Min_Voltage_Limit, 12,  sizeof(s_Min_Voltage_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 13,  sizeof(s_Max_Voltage_Limit)-1, 1},
+    {s_Max_Torque, 14,  sizeof(s_Max_Torque)-1, 2},
+    {s_Status_Return_Level, 16,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Alarm_LED, 17,  sizeof(s_Alarm_LED)-1, 1},
+    {s_Shutdown, 18,  sizeof(s_Shutdown)-1, 1},
+    {s_Multi_Turn_Offset, 20,  sizeof(s_Multi_Turn_Offset)-1, 2},
+    {s_Resolution_Divider, 22,  sizeof(s_Resolution_Divider)-1, 1},
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
-  item[13] = {73 , "Goal_Acceleration"             , 1};
+    {s_Torque_Enable, 24,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 25,  sizeof(s_LED)-1, 1},
+    {s_D_gain, 26,  sizeof(s_D_gain)-1, 1},
+    {s_I_gain, 27,  sizeof(s_I_gain)-1, 1},
+    {s_P_gain, 28,  sizeof(s_P_gain)-1, 1},
+    {s_Goal_Position, 30,  sizeof(s_Goal_Position)-1, 2},
+    {s_Moving_Speed, 32,  sizeof(s_Moving_Speed)-1, 2},
+    {s_Torque_Limit, 34,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Present_Position, 36,  sizeof(s_Present_Position)-1, 2},
+    {s_Present_Speed, 38,  sizeof(s_Present_Speed)-1, 2},
+    {s_Present_Load, 40,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Voltage, 42,  sizeof(s_Present_Voltage)-1, 1},
+    {s_Present_Temperature, 43,  sizeof(s_Present_Temperature)-1, 1},
+    {s_Registered, 44,  sizeof(s_Registered)-1, 1},
+    {s_Moving, 46,  sizeof(s_Moving)-1, 1},
+    {s_Lock, 47,  sizeof(s_Lock)-1, 1},
+    {s_Punch, 48,  sizeof(s_Punch)-1, 2},
+    {s_Goal_Acceleration, 73,  sizeof(s_Goal_Acceleration)-1, 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-  item[14] = {20 , "Multi_Turn_Offset"             , 2};
-  item[15] = {22 , "Resolution_Divider"            , 1};
-
-  item[16] = {24 , "Torque_Enable"                 , 1};
-  item[17] = {25 , "LED"                           , 1};
-  item[18] = {26 , "D_gain"                        , 1};
-  item[19] = {27 , "I_gain"                        , 1};
-  item[20] = {28 , "P_gain"                        , 1};
-  item[21] = {30 , "Goal_Position"                 , 2};
-  item[22] = {32 , "Moving_Speed"                  , 2};
-  item[23] = {34 , "Torque_Limit"                  , 2};
-  item[24] = {36 , "Present_Position"              , 2};
-  item[25] = {38 , "Present_Speed"                 , 2};
-  item[26] = {40 , "Present_Load"                  , 2};
-  item[27] = {42 , "Present_Voltage"               , 1};
-  item[28] = {43 , "Present_Temperature"           , 1};
-  item[29] = {44 , "Registered"                    , 1};
-  item[30] = {46 , "Moving"                        , 1};
-  item[31] = {47 , "Lock"                          , 1};
-  item[32] = {48 , "Punch"                         , 2};
-  item[33] = {73 , "Goal_Acceleration"             , 1};
-
-  the_number_of_item = 34;
-#endif  
-}
+#define COUNT_MX_ITEMS (sizeof(items_MX)/sizeof(items_MX[0]))
 
 static void setMXInfo()
 {
@@ -314,81 +330,63 @@ static void setMXInfo()
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setMX2Item(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {10 , "Drive_Mode"            , 1};
-  item[3]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// MX Protocol 2 servos - (num == MX_28_2)
+//---------------------------------------------------------
+static const ControlTableItem items_MX2[] {
+      {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+      {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+      {s_ID, 7,  sizeof(s_ID)-1, 1},
+      {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+      {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+      {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+      {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+      {s_Secondary_ID, 12,  sizeof(s_Secondary_ID)-1, 1},
+      {s_Protocol_Version, 13,  sizeof(s_Protocol_Version)-1, 1},
+      {s_Homing_Offset, 20,  sizeof(s_Homing_Offset)-1, 4},
+      {s_Moving_Threshold, 24,  sizeof(s_Moving_Threshold)-1, 4},
+      {s_Temperature_Limit, 31,  sizeof(s_Temperature_Limit)-1, 1},
+      {s_Max_Voltage_Limit, 32,  sizeof(s_Max_Voltage_Limit)-1, 2},
+      {s_Min_Voltage_Limit, 34,  sizeof(s_Min_Voltage_Limit)-1, 2},
+      {s_PWM_Limit, 36,  sizeof(s_PWM_Limit)-1, 2},
+      {s_Acceleration_Limit, 40,  sizeof(s_Acceleration_Limit)-1, 4},
+      {s_Velocity_Limit, 44,  sizeof(s_Velocity_Limit)-1, 4},
+      {s_Max_Position_Limit, 48,  sizeof(s_Max_Position_Limit)-1, 4},
+      {s_Min_Position_Limit, 52,  sizeof(s_Min_Position_Limit)-1, 4},
+      {s_Shutdown, 63,  sizeof(s_Shutdown)-1, 1},
 
-  item[4]  = {64 , "Torque_Enable"         , 1};
-  item[5]  = {65 , "LED"                   , 1};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Load"          , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+      {s_Torque_Enable, 64,  sizeof(s_Torque_Enable)-1, 1},
+      {s_LED, 65,  sizeof(s_LED)-1, 1},
+      {s_Status_Return_Level, 68,  sizeof(s_Status_Return_Level)-1, 1},
+      {s_Registered_Instruction, 69,  sizeof(s_Registered_Instruction)-1, 1},
+      {s_Hardware_Error_Status, 70,  sizeof(s_Hardware_Error_Status)-1, 1},
+      {s_Velocity_I_Gain, 76,  sizeof(s_Velocity_I_Gain)-1, 2},
+      {s_Velocity_P_Gain, 78,  sizeof(s_Velocity_P_Gain)-1, 2},
+      {s_Position_D_Gain, 80,  sizeof(s_Position_D_Gain)-1, 2},
+      {s_Position_I_Gain, 82,  sizeof(s_Position_I_Gain)-1, 2},
+      {s_Position_P_Gain, 84,  sizeof(s_Position_P_Gain)-1, 2},
+      {s_Feedforward_2nd_Gain, 88,  sizeof(s_Feedforward_2nd_Gain)-1, 2},
+      {s_Feedforward_1st_Gain, 90,  sizeof(s_Feedforward_1st_Gain)-1, 2},
+      {s_Bus_Watchdog, 98,  sizeof(s_Bus_Watchdog)-1, 1},
+      {s_Goal_PWM, 100,  sizeof(s_Goal_PWM)-1, 2},
+      {s_Goal_Velocity, 104,  sizeof(s_Goal_Velocity)-1, 4},
+      {s_Profile_Acceleration, 108,  sizeof(s_Profile_Acceleration)-1, 4},
+      {s_Profile_Velocity, 112,  sizeof(s_Profile_Velocity)-1, 4},
+      {s_Goal_Position, 116,  sizeof(s_Goal_Position)-1, 4},
+      {s_Realtime_Tick, 120,  sizeof(s_Realtime_Tick)-1, 2},
+      {s_Moving, 122,  sizeof(s_Moving)-1, 1},
+      {s_Moving_Status, 123,  sizeof(s_Moving_Status)-1, 1},
+      {s_Present_PWM, 124,  sizeof(s_Present_PWM)-1, 2},
+      {s_Present_Load, 126,  sizeof(s_Present_Load)-1, 2},
+      {s_Present_Velocity, 128,  sizeof(s_Present_Velocity)-1, 4},
+      {s_Present_Position, 132,  sizeof(s_Present_Position)-1, 4},
+      {s_Velocity_Trajectory, 136,  sizeof(s_Velocity_Trajectory)-1, 4},
+      {s_Position_Trajectory, 140,  sizeof(s_Position_Trajectory)-1, 4},
+      {s_Present_Input_Voltage, 144,  sizeof(s_Present_Input_Voltage)-1, 2},
+      {s_Present_Temperature, 146,  sizeof(s_Present_Temperature)-1, 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Acceleration_Limit"    , 4};
-  item[16] = {44 , "Velocity_Limit"        , 4};
-  item[17] = {48 , "Max_Position_Limit"    , 4};
-  item[18] = {52 , "Min_Position_Limit"    , 4};
-  item[19] = {63 , "Shutdown"              , 1};
+#define COUNT_MX2_ITEMS (sizeof(items_MX2)/sizeof(items_MX2[0]))
 
-  item[20] = {64 , "Torque_Enable"         , 1};
-  item[21] = {65 , "LED"                   , 1};
-  item[22] = {68 , "Status_Return_Level"   , 1};
-  item[23] = {69 , "Registered_Instruction", 1};
-  item[24] = {70 , "Hardware_Error_Status" , 1};
-  item[25] = {76 , "Velocity_I_Gain"       , 2};
-  item[26] = {78 , "Velocity_P_Gain"       , 2};
-  item[27] = {80 , "Position_D_Gain"       , 2};
-  item[28] = {82 , "Position_I_Gain"       , 2};
-  item[29] = {84 , "Position_P_Gain"       , 2};
-  item[30] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[31] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[32] = {98 , "Bus_Watchdog"          , 1};
-  item[33] = {100, "Goal_PWM"              , 2};
-  item[34] = {104, "Goal_Velocity"         , 4};
-  item[35] = {108, "Profile_Acceleration"  , 4};
-  item[36] = {112, "Profile_Velocity"      , 4};
-  item[37] = {116, "Goal_Position"         , 4};
-  item[38] = {120, "Realtime_Tick"         , 2};
-  item[39] = {122, "Moving"                , 1};
-  item[40] = {123, "Moving_Status"         , 1};
-  item[41] = {124, "Present_PWM"           , 2};
-  item[42] = {126, "Present_Load"          , 2};
-  item[43] = {128, "Present_Velocity"      , 4};
-  item[44] = {132, "Present_Position"      , 4};
-  item[45] = {136, "Velocity_Trajectory"   , 4};
-  item[46] = {140, "Position_Trajectory"   , 4};
-  item[47] = {144, "Present_Input_Voltage" , 2};
-  item[48] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 49;
-#endif  
-}
 
 static void setMX2Info(void)
 {
@@ -402,72 +400,50 @@ static void setMX2Info(void)
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setExtMXItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//---------------------------------------------------------
+// EXT MX Protocol 1 servos - (num == MX_64 || num == MX_106)
+//---------------------------------------------------------
+static const ControlTableItem items_EXTMX[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 2,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 3,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 4,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 5,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_CW_Angle_Limit, 6,  sizeof(s_CW_Angle_Limit)-1, 2},
+    {s_CCW_Angle_Limit, 8,  sizeof(s_CCW_Angle_Limit)-1, 2},
+    {s_Temperature_Limit, 11,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Min_Voltage_Limit, 12,  sizeof(s_Min_Voltage_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 13,  sizeof(s_Max_Voltage_Limit)-1, 1},
+    {s_Max_Torque, 14,  sizeof(s_Max_Torque)-1, 2},
+    {s_Status_Return_Level, 16,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Alarm_LED, 17,  sizeof(s_Alarm_LED)-1, 1},
+    {s_Shutdown, 18,  sizeof(s_Shutdown)-1, 1},
+    {s_Multi_Turn_Offset, 20,  sizeof(s_Multi_Turn_Offset)-1, 2},
+    {s_Resolution_Divider, 22,  sizeof(s_Resolution_Divider)-1, 1},
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
-  // item[13] = {68 , "Current"                       , 2};
-  // item[14] = {70 , "Torque_Control_Mode_Enable"    , 1};
-  // item[15] = {71 , "Goal_Torque"                   , 2};
-  // item[16] = {73 , "Goal_Acceleration"             , 1};
+    {s_Torque_Enable, 24,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 25,  sizeof(s_LED)-1, 1},
+    {s_D_gain, 26,  sizeof(s_D_gain)-1, 1},
+    {s_I_gain, 27,  sizeof(s_I_gain)-1, 1},
+    {s_P_gain, 28,  sizeof(s_P_gain)-1, 1},
+    {s_Goal_Position, 30,  sizeof(s_Goal_Position)-1, 2},
+    {s_Moving_Speed, 32,  sizeof(s_Moving_Speed)-1, 2},
+    {s_Torque_Limit, 34,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Present_Position, 36,  sizeof(s_Present_Position)-1, 2},
+    {s_Present_Speed, 38,  sizeof(s_Present_Speed)-1, 2},
+    {s_Present_Load, 40,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Voltage, 42,  sizeof(s_Present_Voltage)-1, 1},
+    {s_Present_Temperature, 43,  sizeof(s_Present_Temperature)-1, 1},
+    {s_Registered, 44,  sizeof(s_Registered)-1, 1},
+    {s_Moving, 46,  sizeof(s_Moving)-1, 1},
+    {s_Lock, 47,  sizeof(s_Lock)-1, 1},
+    {s_Punch, 48,  sizeof(s_Punch)-1, 2},
+    {s_Current, 68,  sizeof(s_Current)-1, 2},
+    {s_Torque_Control_Mode_Enable, 70,  sizeof(s_Torque_Control_Mode_Enable)-1, 1},
+    {s_Goal_Torque, 71,  sizeof(s_Goal_Torque)-1, 2},
+    {s_Goal_Acceleration, 73,  sizeof(s_Goal_Acceleration)-1, 1} };
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-  item[14] = {20 , "Multi_Turn_Offset"             , 2};
-  item[15] = {22 , "Resolution_Divider"            , 1};
-
-  item[16] = {24 , "Torque_Enable"                 , 1};
-  item[17] = {25 , "LED"                           , 1};
-  item[18] = {26 , "D_gain"                        , 1};
-  item[19] = {27 , "I_gain"                        , 1};
-  item[20] = {28 , "P_gain"                        , 1};
-  item[21] = {30 , "Goal_Position"                 , 2};
-  item[22] = {32 , "Moving_Speed"                  , 2};
-  item[23] = {34 , "Torque_Limit"                  , 2};
-  item[24] = {36 , "Present_Position"              , 2};
-  item[25] = {38 , "Present_Speed"                 , 2};
-  item[26] = {40 , "Present_Load"                  , 2};
-  item[27] = {42 , "Present_Voltage"               , 1};
-  item[28] = {43 , "Present_Temperature"           , 1};
-  item[29] = {44 , "Registered"                    , 1};
-  item[30] = {46 , "Moving"                        , 1};
-  item[31] = {47 , "Lock"                          , 1};
-  item[32] = {48 , "Punch"                         , 2};
-  item[33] = {68 , "Current"                       , 2};
-  item[34] = {70 , "Torque_Control_Mode_Enable"    , 1};
-  item[35] = {71 , "Goal_Torque"                   , 2};
-  item[36] = {73 , "Goal_Acceleration"             , 1};
-
-  the_number_of_item = 37;
-#endif  
-}
+#define COUNT_EXTMX_ITEMS (sizeof(items_EXTMX)/sizeof(items_EXTMX[0]))
 
 static void setExtMXInfo()
 {
@@ -481,83 +457,64 @@ static void setExtMXInfo()
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setExtMX2Item(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// EXT MX Protocol 2 Servos - (num == MX_64_2 || num == MX_106_2)
+//---------------------------------------------------------
+static const ControlTableItem items_EXTMX2[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Secondary_ID, 12,  sizeof(s_Secondary_ID)-1, 1},
+    {s_Protocol_Version, 13,  sizeof(s_Protocol_Version)-1, 1},
+    {s_Homing_Offset, 20,  sizeof(s_Homing_Offset)-1, 4},
+    {s_Moving_Threshold, 24,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 31,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 32,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 34,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_PWM_Limit, 36,  sizeof(s_PWM_Limit)-1, 2},
+    {s_Current_Limit, 40,  sizeof(s_Current_Limit)-1, 2},
+    {s_Acceleration_Limit, 40,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Velocity_Limit, 44,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 48,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 52,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_Shutdown, 63,  sizeof(s_Shutdown)-1, 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {s_Torque_Enable, 64,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 65,  sizeof(s_LED)-1, 1},
+    {s_Status_Return_Level, 68,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Registered_Instruction, 69,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Hardware_Error_Status, 70,  sizeof(s_Hardware_Error_Status)-1, 1},
+    {s_Velocity_I_Gain, 76,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 78,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_D_Gain, 80,  sizeof(s_Position_D_Gain)-1, 2},
+    {s_Position_I_Gain, 82,  sizeof(s_Position_I_Gain)-1, 2},
+    {s_Position_P_Gain, 84,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Feedforward_2nd_Gain, 88,  sizeof(s_Feedforward_2nd_Gain)-1, 2},
+    {s_Feedforward_1st_Gain, 90,  sizeof(s_Feedforward_1st_Gain)-1, 2},
+    {s_Bus_Watchdog, 98,  sizeof(s_Bus_Watchdog)-1, 1},
+    {s_Goal_PWM, 100,  sizeof(s_Goal_PWM)-1, 2},
+    {s_Goal_Current, 102,  sizeof(s_Goal_Current)-1, 2},
+    {s_Goal_Velocity, 104,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Profile_Acceleration, 108,  sizeof(s_Profile_Acceleration)-1, 4},
+    {s_Profile_Velocity, 112,  sizeof(s_Profile_Velocity)-1, 4},
+    {s_Goal_Position, 116,  sizeof(s_Goal_Position)-1, 4},
+    {s_Realtime_Tick, 120,  sizeof(s_Realtime_Tick)-1, 2},
+    {s_Moving, 122,  sizeof(s_Moving)-1, 1},
+    {s_Moving_Status, 123,  sizeof(s_Moving_Status)-1, 1},
+    {s_Present_PWM, 124,  sizeof(s_Present_PWM)-1, 2},
+    {s_Present_Current, 126,  sizeof(s_Present_Current)-1, 2},
+    {s_Present_Velocity, 128,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Position, 132,  sizeof(s_Present_Position)-1, 4},
+    {s_Velocity_Trajectory, 136,  sizeof(s_Velocity_Trajectory)-1, 4},
+    {s_Position_Trajectory, 140,  sizeof(s_Position_Trajectory)-1, 4},
+    {s_Present_Input_Voltage, 144,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 146,  sizeof(s_Present_Temperature)-1, 1}};
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {63 , "Shutdown"              , 1};
-
-  item[21] = {64 , "Torque_Enable"         , 1};
-  item[22] = {65 , "LED"                   , 1};
-  item[23] = {68 , "Status_Return_Level"   , 1};
-  item[24] = {69 , "Registered_Instruction", 1};
-  item[25] = {70 , "Hardware_Error_Status" , 1};
-  item[26] = {76 , "Velocity_I_Gain"       , 2};
-  item[27] = {78 , "Velocity_P_Gain"       , 2};
-  item[28] = {80 , "Position_D_Gain"       , 2};
-  item[29] = {82 , "Position_I_Gain"       , 2};
-  item[30] = {84 , "Position_P_Gain"       , 2};
-  item[31] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[32] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[33] = {98 , "Bus_Watchdog"          , 1};
-  item[34] = {100, "Goal_PWM"              , 2};
-  item[35] = {102, "Goal_Current"          , 2};
-  item[36] = {104, "Goal_Velocity"         , 4};
-  item[37] = {108, "Profile_Acceleration"  , 4};
-  item[38] = {112, "Profile_Velocity"      , 4};
-  item[39] = {116, "Goal_Position"         , 4};
-  item[40] = {120, "Realtime_Tick"         , 2};
-  item[41] = {122, "Moving"                , 1};
-  item[42] = {123, "Moving_Status"         , 1};
-  item[43] = {124, "Present_PWM"           , 2};
-  item[44] = {126, "Present_Current"       , 2};
-  item[45] = {128, "Present_Velocity"      , 4};
-  item[46] = {132, "Present_Position"      , 4};
-  item[47] = {136, "Velocity_Trajectory"   , 4};
-  item[48] = {140, "Position_Trajectory"   , 4};
-  item[49] = {144, "Present_Input Voltage" , 2};
-  item[50] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 51;
-#endif  
-}
+#define COUNT_EXTMX2_ITEMS (sizeof(items_EXTMX2)/sizeof(items_EXTMX2[0]))
 
 static void setExtMX2Info(void)
 {
@@ -571,63 +528,44 @@ static void setExtMX2Info(void)
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setXL320Item()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[4]  = {11 , "Control_Mode"                  , 1};
+//---------------------------------------------------------
+// XL320 - (num == XL_320)
+//---------------------------------------------------------
+static const ControlTableItem items_XL320[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 2,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 3,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 4,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 5,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_CW_Angle_Limit, 6,  sizeof(s_CW_Angle_Limit)-1, 2},
+    {s_CCW_Angle_Limit, 8,  sizeof(s_CCW_Angle_Limit)-1, 2},
+    {s_Control_Mode, 11,  sizeof(s_Control_Mode)-1, 1},
+    {s_Temperature_Limit, 12,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Min_Voltage_Limit, 13,  sizeof(s_Min_Voltage_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 14,  sizeof(s_Max_Voltage_Limit)-1, 1},
+    {s_Max_Torque, 15,  sizeof(s_Max_Torque)-1, 2},
+    {s_Status_Return_Level, 17,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Shutdown, 18,  sizeof(s_Shutdown)-1, 1},
 
-  item[5]  = {24 , "Torque_ON/OFF"                 , 1};
-  item[6]  = {25 , "LED"                           , 1};
-  item[7]  = {30 , "Goal_Position"                 , 2};
-  item[8]  = {32 , "Moving_Speed"                  , 2};
-  item[9]  = {34 , "Torque_Limit"                  , 2};
-  item[10] = {37 , "Present_Position"              , 2};
-  item[11] = {39 , "Present_Speed"                 , 2};
-  item[12] = {41 , "Present_Load"                  , 2};
-  item[13] = {49 , "Moving"                        , 1};
+    {s_Torque_Enable, 24,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 25,  sizeof(s_LED)-1, 1},
+    {s_D_gain, 27,  sizeof(s_D_gain)-1, 1},
+    {s_I_gain, 28,  sizeof(s_I_gain)-1, 1},
+    {s_P_gain, 29,  sizeof(s_P_gain)-1, 1},
+    {s_Goal_Position, 30,  sizeof(s_Goal_Position)-1, 2},
+    {s_Moving_Speed, 32,  sizeof(s_Moving_Speed)-1, 2},
+    {s_Torque_Limit, 34,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Present_Position, 37,  sizeof(s_Present_Position)-1, 2},
+    {s_Present_Speed, 39,  sizeof(s_Present_Speed)-1, 2},
+    {s_Present_Load, 41,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Voltage, 45,  sizeof(s_Present_Voltage)-1, 1},
+    {s_Present_Temperature, 46,  sizeof(s_Present_Temperature)-1, 1},
+    {s_Registered, 47,  sizeof(s_Registered)-1, 1},
+    {s_Moving, 49,  sizeof(s_Moving)-1, 1},
+    {s_Hardware_Error_Status, 50,  sizeof(s_Hardware_Error_Status)-1, 1},
+    {s_Punch, 51,  sizeof(s_Punch)-1, 2} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Control_Mode"                  , 1};
-  item[8]  = {12 , "Temperature_Limit"             , 1};
-  item[9]  = {13 , "Min_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Voltage_Limit"             , 1};
-  item[11] = {15 , "Max_Torque"                    , 2};
-  item[12] = {17 , "Status_Return_Level"           , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-
-  item[14] = {24 , "Torque_Enable"                 , 1};
-  item[15] = {25 , "LED"                           , 1};
-  item[16] = {27 , "D_gain"                        , 1};
-  item[17] = {28 , "I_gain"                        , 1};
-  item[18] = {29 , "P_gain"                        , 1};
-  item[19] = {30 , "Goal_Position"                 , 2};
-  item[20] = {32 , "Moving_Speed"                  , 2};
-  item[21] = {34 , "Torque_Limit"                  , 2};
-  item[22] = {37 , "Present_Position"              , 2};
-  item[23] = {39 , "Present_Speed"                 , 2};
-  item[24] = {41 , "Present_Load"                  , 2};
-  item[25] = {45 , "Present_Voltage"               , 1};
-  item[26] = {46 , "Present_Temperature"           , 1};
-  item[27] = {47 , "Registered"                    , 1};
-  item[28] = {49 , "Moving"                        , 1};
-  item[29] = {50 , "Hardware_Error_Status"         , 1};
-  item[30] = {51 , "Punch"                         , 2};
-
-  the_number_of_item = 31;
-#endif  
-}
+#define COUNT_XL320_ITEMS (sizeof(items_XL320)/sizeof(items_XL320[0]))
 
 static void setXL320Info()
 {
@@ -641,81 +579,62 @@ static void setXL320Info()
   model_info.max_radian                      =  2.61799;
 }
 
-static void setXLItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// XL - (num == XL430_W250)
+//---------------------------------------------------------
+static const ControlTableItem items_XL[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Secondary_ID, 12,  sizeof(s_Secondary_ID)-1, 1},
+    {s_Protocol_Version, 13,  sizeof(s_Protocol_Version)-1, 1},
+    {s_Homing_Offset, 20,  sizeof(s_Homing_Offset)-1, 4},
+    {s_Moving_Threshold, 24,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 31,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 32,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 34,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_PWM_Limit, 36,  sizeof(s_PWM_Limit)-1, 2},
+    {s_Acceleration_Limit, 40,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Velocity_Limit, 44,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 48,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 52,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_Shutdown, 63,  sizeof(s_Shutdown)-1, 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Load"          , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {s_Torque_Enable, 64,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 65,  sizeof(s_LED)-1, 1},
+    {s_Status_Return_Level, 68,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Registered_Instruction, 69,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Hardware_Error_Status, 70,  sizeof(s_Hardware_Error_Status)-1, 1},
+    {s_Velocity_I_Gain, 76,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 78,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_D_Gain, 80,  sizeof(s_Position_D_Gain)-1, 2},
+    {s_Position_I_Gain, 82,  sizeof(s_Position_I_Gain)-1, 2},
+    {s_Position_P_Gain, 84,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Feedforward_2nd_Gain, 88,  sizeof(s_Feedforward_2nd_Gain)-1, 2},
+    {s_Feedforward_1st_Gain, 90,  sizeof(s_Feedforward_1st_Gain)-1, 2},
+    {s_Bus_Watchdog, 98,  sizeof(s_Bus_Watchdog)-1, 1},
+    {s_Goal_PWM, 100,  sizeof(s_Goal_PWM)-1, 2},
+    {s_Goal_Velocity, 104,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Profile_Acceleration, 108,  sizeof(s_Profile_Acceleration)-1, 4},
+    {s_Profile_Velocity, 112,  sizeof(s_Profile_Velocity)-1, 4},
+    {s_Goal_Position, 116,  sizeof(s_Goal_Position)-1, 4},
+    {s_Realtime_Tick, 120,  sizeof(s_Realtime_Tick)-1, 2},
+    {s_Moving, 122,  sizeof(s_Moving)-1, 1},
+    {s_Moving_Status, 123,  sizeof(s_Moving_Status)-1, 1},
+    {s_Present_PWM, 124,  sizeof(s_Present_PWM)-1, 2},
+    {s_Present_Load, 126,  sizeof(s_Present_Load)-1, 2},
+    {s_Present_Velocity, 128,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Position, 132,  sizeof(s_Present_Position)-1, 4},
+    {s_Velocity_Trajectory, 136,  sizeof(s_Velocity_Trajectory)-1, 4},
+    {s_Position_Trajectory, 140,  sizeof(s_Position_Trajectory)-1, 4},
+    {s_Present_Input_Voltage, 144,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 146,  sizeof(s_Present_Temperature)-1, 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Acceleration_Limit"    , 4};
-  item[16] = {44 , "Velocity_Limit"        , 4};
-  item[17] = {48 , "Max_Position_Limit"    , 4};
-  item[18] = {52 , "Min_Position_Limit"    , 4};
-  item[19] = {63 , "Shutdown"              , 1};
-
-  item[20] = {64 , "Torque_Enable"         , 1};
-  item[21] = {65 , "LED"                   , 1};
-  item[22] = {68 , "Status_Return_Level"   , 1};
-  item[23] = {69 , "Registered_Instruction", 1};
-  item[24] = {70 , "Hardware_Error_Status" , 1};
-  item[25] = {76 , "Velocity_I_Gain"       , 2};
-  item[26] = {78 , "Velocity_P_Gain"       , 2};
-  item[27] = {80 , "Position_D_Gain"       , 2};
-  item[28] = {82 , "Position_I_Gain"       , 2};
-  item[29] = {84 , "Position_P_Gain"       , 2};
-  item[30] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[31] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[32] = {98 , "Bus_Watchdog"          , 1};
-  item[33] = {100, "Goal_PWM"              , 2};
-  item[34] = {104, "Goal_Velocity"         , 4};
-  item[35] = {108, "Profile_Acceleration"  , 4};
-  item[36] = {112, "Profile_Velocity"      , 4};
-  item[37] = {116, "Goal_Position"         , 4};
-  item[38] = {120, "Realtime_Tick"         , 2};
-  item[39] = {122, "Moving"                , 1};
-  item[40] = {123, "Moving_Status"         , 1};
-  item[41] = {124, "Present_PWM"           , 2};
-  item[42] = {126, "Present_Load"          , 2};
-  item[43] = {128, "Present_Velocity"      , 4};
-  item[44] = {132, "Present_Position"      , 4};
-  item[45] = {136, "Velocity_Trajectory"   , 4};
-  item[46] = {140, "Position_Trajectory"   , 4};
-  item[47] = {144, "Present_Input_Voltage" , 2};
-  item[48] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 49;
-#endif  
-}
+#define COUNT_XL_ITEMS (sizeof(items_XL)/sizeof(items_XL[0]))
 
 static void setXLInfo()
 {
@@ -729,83 +648,64 @@ static void setXLInfo()
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setXMItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// XM - (num == XM430_W210 || num == XM430_W350)
+//---------------------------------------------------------
+static const ControlTableItem items_XM[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Secondary_ID, 12,  sizeof(s_Secondary_ID)-1, 1},
+    {s_Protocol_Version, 13,  sizeof(s_Protocol_Version)-1, 1},
+    {s_Homing_Offset, 20,  sizeof(s_Homing_Offset)-1, 4},
+    {s_Moving_Threshold, 24,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 31,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 32,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 34,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_PWM_Limit, 36,  sizeof(s_PWM_Limit)-1, 2},
+    {s_Current_Limit, 40,  sizeof(s_Current_Limit)-1, 2},
+    {s_Acceleration_Limit, 40,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Velocity_Limit, 44,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 48,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 52,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_Shutdown, 63,  sizeof(s_Shutdown)-1, 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {s_Torque_Enable, 64,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 65,  sizeof(s_LED)-1, 1},
+    {s_Status_Return_Level, 68,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Registered_Instruction, 69,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Hardware_Error_Status, 70,  sizeof(s_Hardware_Error_Status)-1, 1},
+    {s_Velocity_I_Gain, 76,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 78,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_D_Gain, 80,  sizeof(s_Position_D_Gain)-1, 2},
+    {s_Position_I_Gain, 82,  sizeof(s_Position_I_Gain)-1, 2},
+    {s_Position_P_Gain, 84,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Feedforward_2nd_Gain, 88,  sizeof(s_Feedforward_2nd_Gain)-1, 2},
+    {s_Feedforward_1st_Gain, 90,  sizeof(s_Feedforward_1st_Gain)-1, 2},
+    {s_Bus_Watchdog, 98,  sizeof(s_Bus_Watchdog)-1, 1},
+    {s_Goal_PWM, 100,  sizeof(s_Goal_PWM)-1, 2},
+    {s_Goal_Current, 102,  sizeof(s_Goal_Current)-1, 2},
+    {s_Goal_Velocity, 104,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Profile_Acceleration, 108,  sizeof(s_Profile_Acceleration)-1, 4},
+    {s_Profile_Velocity, 112,  sizeof(s_Profile_Velocity)-1, 4},
+    {s_Goal_Position, 116,  sizeof(s_Goal_Position)-1, 4},
+    {s_Realtime_Tick, 120,  sizeof(s_Realtime_Tick)-1, 2},
+    {s_Moving, 122,  sizeof(s_Moving)-1, 1},
+    {s_Moving_Status, 123,  sizeof(s_Moving_Status)-1, 1},
+    {s_Present_PWM, 124,  sizeof(s_Present_PWM)-1, 2},
+    {s_Present_Current, 126,  sizeof(s_Present_Current)-1, 2},
+    {s_Present_Velocity, 128,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Position, 132,  sizeof(s_Present_Position)-1, 4},
+    {s_Velocity_Trajectory, 136,  sizeof(s_Velocity_Trajectory)-1, 4},
+    {s_Position_Trajectory, 140,  sizeof(s_Position_Trajectory)-1, 4},
+    {s_Present_Input_Voltage, 144,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 146,  sizeof(s_Present_Temperature)-1, 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {63 , "Shutdown"              , 1};
-
-  item[21] = {64 , "Torque_Enable"         , 1};
-  item[22] = {65 , "LED"                   , 1};
-  item[23] = {68 , "Status_Return_Level"   , 1};
-  item[24] = {69 , "Registered_Instruction", 1};
-  item[25] = {70 , "Hardware_Error_Status" , 1};
-  item[26] = {76 , "Velocity_I_Gain"       , 2};
-  item[27] = {78 , "Velocity_P_Gain"       , 2};
-  item[28] = {80 , "Position_D_Gain"       , 2};
-  item[29] = {82 , "Position_I_Gain"       , 2};
-  item[30] = {84 , "Position_P_Gain"       , 2};
-  item[31] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[32] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[33] = {98 , "Bus_Watchdog"          , 1};
-  item[34] = {100, "Goal_PWM"              , 2};
-  item[35] = {102, "Goal_Current"          , 2};
-  item[36] = {104, "Goal_Velocity"         , 4};
-  item[37] = {108, "Profile_Acceleration"  , 4};
-  item[38] = {112, "Profile_Velocity"      , 4};
-  item[39] = {116, "Goal_Position"         , 4};
-  item[40] = {120, "Realtime_Tick"         , 2};
-  item[41] = {122, "Moving"                , 1};
-  item[42] = {123, "Moving_Status"         , 1};
-  item[43] = {124, "Present_PWM"           , 2};
-  item[44] = {126, "Present_Current"       , 2};
-  item[45] = {128, "Present_Velocity"      , 4};
-  item[46] = {132, "Present_Position"      , 4};
-  item[47] = {136, "Velocity_Trajectory"   , 4};
-  item[48] = {140, "Position_Trajectory"   , 4};
-  item[49] = {144, "Present_Input_Voltage" , 2};
-  item[50] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 51;
-#endif  
-}
+#define COUNT_XM_ITEMS (sizeof(items_XM)/sizeof(items_XM[0]))
 
 static void setXMInfo()
 {
@@ -820,86 +720,67 @@ static void setXMInfo()
   model_info.max_radian =  3.14159265;
 }
 
-static void setExtXMItem(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// EXTXM - (num == XM540_W150 || num == XM540_W270)
+//---------------------------------------------------------
+static const ControlTableItem items_EXTXM[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Secondary_ID, 12,  sizeof(s_Secondary_ID)-1, 1},
+    {s_Protocol_Version, 13,  sizeof(s_Protocol_Version)-1, 1},
+    {s_Homing_Offset, 20,  sizeof(s_Homing_Offset)-1, 4},
+    {s_Moving_Threshold, 24,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 31,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 32,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 34,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_PWM_Limit, 36,  sizeof(s_PWM_Limit)-1, 2},
+    {s_Current_Limit, 40,  sizeof(s_Current_Limit)-1, 2},
+    {s_Acceleration_Limit, 40,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Velocity_Limit, 44,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 48,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 52,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_External_Port_Mode_1, 56,  sizeof(s_External_Port_Mode_1)-1, 1},
+    {s_External_Port_Mode_2, 57,  sizeof(s_External_Port_Mode_2)-1, 1},
+    {s_External_Port_Mode_3, 58,  sizeof(s_External_Port_Mode_3)-1, 1},
+    {s_Shutdown, 63,  sizeof(s_Shutdown)-1, 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9] = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {s_Torque_Enable, 64,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 65,  sizeof(s_LED)-1, 1},
+    {s_Status_Return_Level, 68,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Registered_Instruction, 69,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Hardware_Error_Status, 70,  sizeof(s_Hardware_Error_Status)-1, 1},
+    {s_Velocity_I_Gain, 76,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 78,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_D_Gain, 80,  sizeof(s_Position_D_Gain)-1, 2},
+    {s_Position_I_Gain, 82,  sizeof(s_Position_I_Gain)-1, 2},
+    {s_Position_P_Gain, 84,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Feedforward_2nd_Gain, 88,  sizeof(s_Feedforward_2nd_Gain)-1, 2},
+    {s_Feedforward_1st_Gain, 90,  sizeof(s_Feedforward_1st_Gain)-1, 2},
+    {s_Bus_Watchdog, 98,  sizeof(s_Bus_Watchdog)-1, 1},
+    {s_Goal_PWM, 100,  sizeof(s_Goal_PWM)-1, 2},
+    {s_Goal_Current, 102,  sizeof(s_Goal_Current)-1, 2},
+    {s_Goal_Velocity, 104,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Profile_Acceleration, 108,  sizeof(s_Profile_Acceleration)-1, 4},
+    {s_Profile_Velocity, 112,  sizeof(s_Profile_Velocity)-1, 4},
+    {s_Goal_Position, 116,  sizeof(s_Goal_Position)-1, 4},
+    {s_Realtime_Tick, 120,  sizeof(s_Realtime_Tick)-1, 2},
+    {s_Moving, 122,  sizeof(s_Moving)-1, 1},
+    {s_Moving_Status, 123,  sizeof(s_Moving_Status)-1, 1},
+    {s_Present_PWM, 124,  sizeof(s_Present_PWM)-1, 2},
+    {s_Present_Current, 126,  sizeof(s_Present_Current)-1, 2},
+    {s_Present_Velocity, 128,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Position, 132,  sizeof(s_Present_Position)-1, 4},
+    {s_Velocity_Trajectory, 136,  sizeof(s_Velocity_Trajectory)-1, 4},
+    {s_Position_Trajectory, 140,  sizeof(s_Position_Trajectory)-1, 4},
+    {s_Present_Input_Voltage, 144,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 146,  sizeof(s_Present_Temperature)-1, 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max Voltage_Limit"     , 2};
-  item[13] = {34 , "Min Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {56 , "External_Port_Mode_1"  , 1};
-  item[21] = {57 , "External_Port_Mode_2"  , 1};
-  item[22] = {58 , "External_Port_Mode_3"  , 1};
-  item[23] = {63 , "Shutdown"              , 1};
-
-  item[24] = {64 , "Torque_Enable"         , 1};
-  item[25] = {65 , "LED"                   , 1};
-  item[26] = {68 , "Status_Return_Level"   , 1};
-  item[27] = {69 , "Registered_Instruction", 1};
-  item[28] = {70 , "Hardware_Error_Status" , 1};
-  item[29] = {76 , "Velocity_I_Gain"       , 2};
-  item[30] = {78 , "Velocity_P_Gain"       , 2};
-  item[31] = {80 , "Position_D_Gain"       , 2};
-  item[32] = {82 , "Position_I_Gain"       , 2};
-  item[33] = {84 , "Position_P_Gain"       , 2};
-  item[34] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[35] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[36] = {98 , "Bus_Watchdog"          , 1};
-  item[37] = {100, "Goal_PWM"              , 2};
-  item[38] = {102, "Goal_Current"          , 2};
-  item[39] = {104, "Goal_Velocity"         , 4};
-  item[40] = {108, "Profile_Acceleration"  , 4};
-  item[41] = {112, "Profile_Velocity"      , 4};
-  item[42] = {116, "Goal_Position"         , 4};
-  item[43] = {120, "Realtime_Tick"         , 2};
-  item[44] = {122, "Moving"                , 1};
-  item[45] = {123, "Moving_Status"         , 1};
-  item[46] = {124, "Present_PWM"           , 2};
-  item[47] = {126, "Present_Current"       , 2};
-  item[48] = {128, "Present_Velocity"      , 4};
-  item[49] = {132, "Present_Position"      , 4};
-  item[50] = {136, "Velocity_Trajectory"   , 4};
-  item[51] = {140, "Position_Trajectory"   , 4};
-  item[52] = {144, "Present_Input_Voltage" , 2};
-  item[53] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 54;
-#endif  
-}
+#define COUNT_EXTXM_ITEMS (sizeof(items_EXTXM)/sizeof(items_EXTXM[0]))
 
 static void setExtXMInfo(void)
 {
@@ -913,83 +794,65 @@ static void setExtXMInfo(void)
   model_info.max_radian =  3.14159265;
 }
 
-static void setXHItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// XH - (num == XH430_V210 || num == XH430_V350 || num == XH430_W210 || num == XH430_W350)
+//---------------------------------------------------------
+static const ControlTableItem items_XH[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Drive_Mode, 10,  sizeof(s_Drive_Mode)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Secondary_ID, 12,  sizeof(s_Secondary_ID)-1, 1},
+    {s_Protocol_Version, 13,  sizeof(s_Protocol_Version)-1, 1},
+    {s_Homing_Offset, 20,  sizeof(s_Homing_Offset)-1, 4},
+    {s_Moving_Threshold, 24,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 31,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 32,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 34,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_PWM_Limit, 36,  sizeof(s_PWM_Limit)-1, 2},
+    {s_Current_Limit, 40,  sizeof(s_Current_Limit)-1, 2},
+    {s_Acceleration_Limit, 40,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Velocity_Limit, 44,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 48,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 52,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_Shutdown, 63,  sizeof(s_Shutdown)-1, 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {s_Torque_Enable, 64,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED, 65,  sizeof(s_LED)-1, 1},
+    {s_Status_Return_Level, 68,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Registered_Instruction, 69,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Hardware_Error_Status, 70,  sizeof(s_Hardware_Error_Status)-1, 1},
+    {s_Velocity_I_Gain, 76,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 78,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_D_Gain, 80,  sizeof(s_Position_D_Gain)-1, 2},
+    {s_Position_I_Gain, 82,  sizeof(s_Position_I_Gain)-1, 2},
+    {s_Position_P_Gain, 84,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Feedforward_2nd_Gain, 88,  sizeof(s_Feedforward_2nd_Gain)-1, 2},
+    {s_Feedforward_1st_Gain, 90,  sizeof(s_Feedforward_1st_Gain)-1, 2},
+    {s_Bus_Watchdog, 98,  sizeof(s_Bus_Watchdog)-1, 1},
+    {s_Goal_PWM, 100,  sizeof(s_Goal_PWM)-1, 2},
+    {s_Goal_Current, 102,  sizeof(s_Goal_Current)-1, 2},
+    {s_Goal_Velocity, 104,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Profile_Acceleration, 108,  sizeof(s_Profile_Acceleration)-1, 4},
+    {s_Profile_Velocity, 112,  sizeof(s_Profile_Velocity)-1, 4},
+    {s_Goal_Position, 116,  sizeof(s_Goal_Position)-1, 4},
+    {s_Realtime_Tick, 120,  sizeof(s_Realtime_Tick)-1, 2},
+    {s_Moving, 122,  sizeof(s_Moving)-1, 1},
+    {s_Moving_Status, 123,  sizeof(s_Moving_Status)-1, 1},
+    {s_Present_PWM, 124,  sizeof(s_Present_PWM)-1, 2},
+    {s_Present_Current, 126,  sizeof(s_Present_Current)-1, 2},
+    {s_Present_Velocity, 128,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Position, 132,  sizeof(s_Present_Position)-1, 4},
+    {s_Velocity_Trajectory, 136,  sizeof(s_Velocity_Trajectory)-1, 4},
+    {s_Position_Trajectory, 140,  sizeof(s_Position_Trajectory)-1, 4},
+    {s_Present_Input_Voltage, 144,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 146,  sizeof(s_Present_Temperature)-1, 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {63 , "Shutdown"              , 1};
+#define COUNT_XH_ITEMS (sizeof(items_XH)/sizeof(items_XH[0]))
 
-  item[21] = {64 , "Torque_Enable"         , 1};
-  item[22] = {65 , "LED"                   , 1};
-  item[23] = {68 , "Status_Return_Level"   , 1};
-  item[24] = {69 , "Registered_Instruction", 1};
-  item[25] = {70 , "Hardware_Error_Status" , 1};
-  item[26] = {76 , "Velocity_I_Gain"       , 2};
-  item[27] = {78 , "Velocity_P_Gain"       , 2};
-  item[28] = {80 , "Position_D_Gain"       , 2};
-  item[29] = {82 , "Position_I_Gain"       , 2};
-  item[30] = {84 , "Position_P_Gain"       , 2};
-  item[31] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[32] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[33] = {98 , "Bus_Watchdog"          , 1};
-  item[34] = {100, "Goal_PWM"              , 2};
-  item[35] = {102, "Goal_Current"          , 2};
-  item[36] = {104, "Goal_Velocity"         , 4};
-  item[37] = {108, "Profile_Acceleration"  , 4};
-  item[38] = {112, "Profile_Velocity"      , 4};
-  item[39] = {116, "Goal_Position"         , 4};
-  item[40] = {120, "Realtime_Tick"         , 2};
-  item[41] = {122, "Moving"                , 1};
-  item[42] = {123, "Moving_Status"         , 1};
-  item[43] = {124, "Present_PWM"           , 2};
-  item[44] = {126, "Present_Current"       , 2};
-  item[45] = {128, "Present_Velocity"      , 4};
-  item[46] = {132, "Present_Position"      , 4};
-  item[47] = {136, "Velocity_Trajectory"   , 4};
-  item[48] = {140, "Position_Trajectory"   , 4};
-  item[49] = {144, "Present_Input_Voltage" , 2};
-  item[50] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 51;
-#endif  
-}
 
 static void setXHInfo()
 {
@@ -1003,146 +866,110 @@ static void setXHInfo()
   model_info.max_radian = 3.14159265;
 }
 
-static void setPROItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// PRO - (num == PRO_L42_10_S300_R)
+//---------------------------------------------------------
+static const ControlTableItem items_PRO[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Moving_Threshold, 17,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 21,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 22,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 24,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_Acceleration_Limit, 26,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Torque_Limit, 30,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Velocity_Limit, 32,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 36,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 40,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_External_Port_Mode_1, 44,  sizeof(s_External_Port_Mode_1)-1, 1},
+    {s_External_Port_Mode_2, 45,  sizeof(s_External_Port_Mode_2)-1, 1},
+    {s_External_Port_Mode_3, 46,  sizeof(s_External_Port_Mode_3)-1, 1},
+    {s_External_Port_Mode_4, 47,  sizeof(s_External_Port_Mode_4)-1, 1},
+    {s_Shutdown, 48,  sizeof(s_Shutdown)-1, 1},
 
-  item[3]  = {562, "Torque_Enable"         , 1};
-  item[4]  = {563, "LED_RED"               , 1};
-  item[5]  = {596, "Goal_Position"         , 4};
-  item[6]  = {600, "Goal_Velocity"         , 4};
-  item[7]  = {604, "Goal_Torque"           , 2};
-  item[8]  = {606, "Goal_Acceleration"     , 4};
-  item[9]  = {610, "Moving"                , 1};
-  item[10] = {611, "Present_Position"      , 4};
-  item[11] = {615, "Present_Velocity"      , 4};
-  item[12] = {621, "Present_Current"       , 2};
+    {s_Torque_Enable, 562,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED_RED, 563,  sizeof(s_LED_RED)-1, 1},
+    {s_LED_GREEN, 564,  sizeof(s_LED_GREEN)-1, 1},
+    {s_LED_BLUE, 565,  sizeof(s_LED_BLUE)-1, 1},
+    {s_Velocity_I_Gain, 586,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 588,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_P_Gain, 594,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Goal_Position, 596,  sizeof(s_Goal_Position)-1, 4},
+    {s_Goal_Velocity, 600,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Goal_Torque, 604,  sizeof(s_Goal_Torque)-1, 2},
+    {s_Goal_Acceleration, 606,  sizeof(s_Goal_Acceleration)-1, 4},
+    {s_Moving, 610,  sizeof(s_Moving)-1, 1},
+    {s_Present_Position, 611,  sizeof(s_Present_Position)-1, 4},
+    {s_Present_Velocity, 615,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Current, 621,  sizeof(s_Present_Current)-1, 2},
+    {s_Present_Input_Voltage, 623,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 625,  sizeof(s_Present_Temperature)-1, 1},
+    {s_External_Port_Mode_1, 626,  sizeof(s_External_Port_Mode_1)-1, 2},
+    {s_External_Port_Mode_2, 628,  sizeof(s_External_Port_Mode_2)-1, 2},
+    {s_External_Port_Mode_3, 630,  sizeof(s_External_Port_Mode_3)-1, 2},
+    {s_External_Port_Mode_4, 632,  sizeof(s_External_Port_Mode_4)-1, 2},
+    {s_Registered_Instruction, 890,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Status_Return_Level, 891,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Hardware_Error_Status, 892,  sizeof(s_Hardware_Error_Status)-1, 1} };
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {11 , "Operating_Mode"        , 1};
-  item[6]  = {17 , "Moving_Threshold"      , 4};
-  item[7]  = {21 , "Temperature_Limit"     , 1};
-  item[8]  = {22 , "Max_Voltage_Limit"     , 2};
-  item[9]  = {24 , "Min_Voltage_Limit"     , 2};
-  item[10] = {26 , "Acceleration_Limit"    , 4};
-  item[11] = {30 , "Torque_Limit"          , 2};
-  item[12] = {32 , "Velocity_Limit"        , 4};
-  item[13] = {36 , "Max_Position_Limit"    , 4};
-  item[14] = {40 , "Min_Position_Limit"    , 4};
-  item[15] = {44 , "External_Port_Mode_1"  , 1};
-  item[16] = {45 , "External_Port_Mode_2"  , 1};
-  item[17] = {46 , "External_Port_Mode_3"  , 1};
-  item[18] = {47 , "External_Port_Mode_4"  , 1};
-  item[19] = {48 , "Shutdown"              , 1};
+#define COUNT_PRO_ITEMS (sizeof(items_PRO)/sizeof(items_PRO[0]))
 
-  item[20] = {562, "Torque_Enable"         , 1};
-  item[21] = {563, "LED_RED"               , 1};
-  item[22] = {564, "LED_GREEN"             , 1};
-  item[23] = {565, "LED_BLUE"              , 1};
-  item[24] = {586, "Velocity_I_Gain"       , 2};
-  item[25] = {588, "Velocity_P_Gain"       , 2};
-  item[26] = {594, "Position_P_Gain"       , 2};
-  item[27] = {596, "Goal_Position"         , 4};
-  item[28] = {600, "Goal_Velocity"         , 4};
-  item[29] = {604, "Goal_Torque"           , 2};
-  item[30] = {606, "Goal_Acceleration"     , 4};
-  item[31] = {610, "Moving"                , 1};
-  item[32] = {611, "Present_Position"      , 4};
-  item[33] = {615, "Present_Velocity"      , 4};
-  item[34] = {621, "Present_Current"       , 2};
-  item[35] = {623, "Present_Input_Voltage" , 2};
-  item[36] = {625, "Present_Temperature"   , 1};
-  item[37] = {626, "External_Port_Mode_1"  , 2};
-  item[38] = {628, "External_Port_Mode_2"  , 2};
-  item[39] = {630, "External_Port_Mode_3"  , 2};
-  item[40] = {632, "External_Port_Mode_4"  , 2};
-  item[41] = {890, "Registered_Instruction", 1};
-  item[42] = {891, "Status_Return_Level"   , 1};
-  item[43] = {892, "Hardware_Error_Status" , 1};
+//---------------------------------------------------------
+// EXT PRO - All Other Pros...
+//---------------------------------------------------------
+static const ControlTableItem items_EXTPRO[] {
+    {s_Model_Number, 0,  sizeof(s_Model_Number)-1, 2},
+    {s_Firmware_Version, 6,  sizeof(s_Firmware_Version)-1, 1},
+    {s_ID, 7,  sizeof(s_ID)-1, 1},
+    {s_Baud_Rate, 8,  sizeof(s_Baud_Rate)-1, 1},
+    {s_Return_Delay_Time, 9,  sizeof(s_Return_Delay_Time)-1, 1},
+    {s_Operating_Mode, 11,  sizeof(s_Operating_Mode)-1, 1},
+    {s_Homing_Offset, 13,  sizeof(s_Homing_Offset)-1, 4},
+    {s_Moving_Threshold, 17,  sizeof(s_Moving_Threshold)-1, 4},
+    {s_Temperature_Limit, 21,  sizeof(s_Temperature_Limit)-1, 1},
+    {s_Max_Voltage_Limit, 22,  sizeof(s_Max_Voltage_Limit)-1, 2},
+    {s_Min_Voltage_Limit, 24,  sizeof(s_Min_Voltage_Limit)-1, 2},
+    {s_Acceleration_Limit, 26,  sizeof(s_Acceleration_Limit)-1, 4},
+    {s_Torque_Limit, 30,  sizeof(s_Torque_Limit)-1, 2},
+    {s_Velocity_Limit, 32,  sizeof(s_Velocity_Limit)-1, 4},
+    {s_Max_Position_Limit, 36,  sizeof(s_Max_Position_Limit)-1, 4},
+    {s_Min_Position_Limit, 40,  sizeof(s_Min_Position_Limit)-1, 4},
+    {s_External_Port_Mode_1, 44,  sizeof(s_External_Port_Mode_1)-1, 1},
+    {s_External_Port_Mode_2, 45,  sizeof(s_External_Port_Mode_2)-1, 1},
+    {s_External_Port_Mode_3, 46,  sizeof(s_External_Port_Mode_3)-1, 1},
+    {s_External_Port_Mode_4, 47,  sizeof(s_External_Port_Mode_4)-1, 1},
+    {s_Shutdown, 48,  sizeof(s_Shutdown)-1, 1},
 
-  the_number_of_item = 44;
-#endif  
-}
+    {s_Torque_Enable, 562,  sizeof(s_Torque_Enable)-1, 1},
+    {s_LED_RED, 563,  sizeof(s_LED_RED)-1, 1},
+    {s_LED_GREEN, 564,  sizeof(s_LED_GREEN)-1, 1},
+    {s_LED_BLUE, 565,  sizeof(s_LED_BLUE)-1, 1},
+    {s_Velocity_I_Gain, 586,  sizeof(s_Velocity_I_Gain)-1, 2},
+    {s_Velocity_P_Gain, 588,  sizeof(s_Velocity_P_Gain)-1, 2},
+    {s_Position_P_Gain, 594,  sizeof(s_Position_P_Gain)-1, 2},
+    {s_Goal_Position, 596,  sizeof(s_Goal_Position)-1, 4},
+    {s_Goal_Velocity, 600,  sizeof(s_Goal_Velocity)-1, 4},
+    {s_Goal_Torque, 604,  sizeof(s_Goal_Torque)-1, 2},
+    {s_Goal_Acceleration, 606,  sizeof(s_Goal_Acceleration)-1, 4},
+    {s_Moving, 610,  sizeof(s_Moving)-1, 1},
+    {s_Present_Position, 611,  sizeof(s_Present_Position)-1, 4},
+    {s_Present_Velocity, 615,  sizeof(s_Present_Velocity)-1, 4},
+    {s_Present_Current, 621,  sizeof(s_Present_Current)-1, 2},
+    {s_Present_Input_Voltage, 623,  sizeof(s_Present_Input_Voltage)-1, 2},
+    {s_Present_Temperature, 625,  sizeof(s_Present_Temperature)-1, 1},
+    {s_External_Port_Mode_1, 626,  sizeof(s_External_Port_Mode_1)-1, 2},
+    {s_External_Port_Mode_2, 628,  sizeof(s_External_Port_Mode_2)-1, 2},
+    {s_External_Port_Mode_3, 630,  sizeof(s_External_Port_Mode_3)-1, 2},
+    {s_External_Port_Mode_4, 632,  sizeof(s_External_Port_Mode_4)-1, 2},
+    {s_Registered_Instruction, 890,  sizeof(s_Registered_Instruction)-1, 1},
+    {s_Status_Return_Level, 891,  sizeof(s_Status_Return_Level)-1, 1},
+    {s_Hardware_Error_Status, 892,  sizeof(s_Hardware_Error_Status)-1, 1} };
 
-static void setExtPROItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
-
-  item[3]  = {562, "Torque_Enable"         , 1};
-  item[4]  = {563, "LED_RED"               , 1};
-  item[5]  = {596, "Goal_Position"         , 4};
-  item[6]  = {600, "Goal_Velocity"         , 4};
-  item[7]  = {604, "Goal_Torque"           , 2};
-  item[8]  = {606, "Goal_Acceleration"     , 4};
-  item[9]  = {610, "Moving"                , 1};
-  item[10] = {611, "Present_Position"      , 4};
-  item[11] = {615, "Present_Velocity"      , 4};
-  item[12] = {621, "Present_Current"       , 2};
-
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {11 , "Operating_Mode"        , 1};
-  item[6]  = {13 , "Homing_Offset"         , 4};
-  item[7]  = {17 , "Moving_Threshold"      , 4};
-  item[8]  = {21 , "Temperature_Limit"     , 1};
-  item[9]  = {22 , "Max_Voltage_Limit"     , 2};
-  item[10] = {24 , "Min_Voltage_Limit"     , 2};
-  item[11] = {26 , "Acceleration_Limit"    , 4};
-  item[12] = {30 , "Torque_Limit"          , 2};
-  item[13] = {32 , "Velocity_Limit"        , 4};
-  item[14] = {36 , "Max_Position_Limit"    , 4};
-  item[15] = {40 , "Min_Position_Limit"    , 4};
-  item[16] = {44 , "External_Port_Mode_1"  , 1};
-  item[17] = {45 , "External_Port_Mode_2"  , 1};
-  item[18] = {46 , "External_Port_Mode_3"  , 1};
-  item[19] = {47 , "External_Port_Mode_4"  , 1};
-  item[20] = {48 , "Shutdown"              , 1};
-
-  item[20] = {562, "Torque_Enable"         , 1};
-  item[21] = {563, "LED_RED"               , 1};
-  item[22] = {564, "LED_GREEN"             , 1};
-  item[23] = {565, "LED_BLUE"              , 1};
-  item[24] = {586, "Velocity_I_Gain"       , 2};
-  item[25] = {588, "Velocity_P_Gain"       , 2};
-  item[26] = {594, "Position_P_Gain"       , 2};
-  item[27] = {596, "Goal_Position"         , 4};
-  item[28] = {600, "Goal_Velocity"         , 4};
-  item[29] = {604, "Goal_Torque"           , 2};
-  item[30] = {606, "Goal_Acceleration"     , 4};
-  item[31] = {610, "Moving"                , 1};
-  item[32] = {611, "Present_Position"      , 4};
-  item[33] = {615, "Present_Velocity"      , 4};
-  item[34] = {621, "Present_Current"       , 2};
-  item[35] = {623, "Present_Input_Voltage" , 2};
-  item[36] = {625, "Present_Temperature"   , 1};
-  item[37] = {626, "External_Port_Mode_1"  , 2};
-  item[38] = {628, "External_Port_Mode_2"  , 2};
-  item[39] = {630, "External_Port_Mode_3"  , 2};
-  item[40] = {632, "External_Port_Mode_4"  , 2};
-  item[41] = {890, "Registered_Instruction", 1};
-  item[42] = {891, "Status_Return_Level"   , 1};
-  item[43] = {892, "Hardware_Error_Status" , 1};
-
-  the_number_of_item = 44;
-#endif  
-}
+#define COUNT_EXTPRO_ITEMS (sizeof(items_EXTPRO)/sizeof(items_EXTPRO[0]))
 
 static void setPROInfo(uint16_t model_number)
 {
@@ -1207,74 +1034,95 @@ static void setPROInfo(uint16_t model_number)
   model_info.max_radian                      =  3.14159265;
 }
 
-ControlTableItem* getConrolTableItem(uint16_t model_number)
+
+//=========================================================
+// Get Servo control table for the specified servo type
+//=========================================================
+const ControlTableItem* getConrolTableItem(uint16_t model_number)
 {
   uint16_t num = model_number;
 
+  const ControlTableItem  *items;
   if (num == AX_12A || num == AX_12W || num == AX_18A)
   {
-    setAXItem();
+    items = items_AX;
+    the_number_of_item = COUNT_AX_ITEMS;
   }
   else if (num == RX_10 || num == RX_24F || num == RX_28 || num == RX_64)
   {
-    setRXItem();
+    items = items_RX;
+    the_number_of_item = COUNT_RX_ITEMS;
   }
   else if (num == EX_106)
   {
-    setEXItem();
+    items = items_EX;
+    the_number_of_item = COUNT_EX_ITEMS;
   }
   else if (num == MX_12W || num == MX_28)
   {
-    setMXItem();
+    items = items_MX;
+    the_number_of_item = COUNT_MX_ITEMS;
   }
   else if (num == MX_64 || num == MX_106)
   {
-    setExtMXItem();
+    items = items_EXTMX;
+    the_number_of_item = COUNT_EXTMX_ITEMS;
   }
   else if (num == MX_28_2)
   {
-    setMX2Item();
+    items = items_MX2;
+    the_number_of_item = COUNT_MX2_ITEMS;
   }
   else if (num == MX_64_2 || num == MX_106_2)
   {
-    setExtMX2Item();
+    items = items_EXTMX2;
+    the_number_of_item = COUNT_EXTMX2_ITEMS;
   }
   else if (num == XL_320)
   {
-    setXL320Item();
+    items = items_XL320;
+    the_number_of_item = COUNT_XL320_ITEMS;
   }
   else if (num == XL430_W250)
   {
-    setXLItem();
+    items = items_XL;
+    the_number_of_item = COUNT_XL_ITEMS;
   }
   else if (num == XM430_W210 || num == XM430_W350)
   {
-    setXMItem();
+    items = items_XM;
+    the_number_of_item = COUNT_XM_ITEMS;
   }
   else if (num == XM540_W150 || num == XM540_W270)
   {
-    setExtXMItem();
+    items = items_EXTXM;
+    the_number_of_item = COUNT_EXTXM_ITEMS;
   }
   else if (num == XH430_V210 || num == XH430_V350 || num == XH430_W210 || num == XH430_W350)
   {
-    setXHItem();
+    items = items_XH;
+    the_number_of_item = COUNT_XH_ITEMS;
   }
   else if (num == PRO_L54_30_S400_R || num == PRO_L54_30_S500_R  || num == PRO_L54_50_S290_R || num == PRO_L54_50_S500_R ||
            num == PRO_M42_10_S260_R || num == PRO_M54_40_S250_R  || num == PRO_M54_60_S250_R || 
            num == PRO_H42_20_S300_R || num == PRO_H54_100_S500_R || num == PRO_H54_200_S500_R)
   {
-    setExtPROItem();
+    items = items_EXTPRO;
+    the_number_of_item = COUNT_EXTPRO_ITEMS;
   }
   else if (num == PRO_L42_10_S300_R)
   {
-    setPROItem();
+    items = items_PRO;
+    the_number_of_item = COUNT_PRO_ITEMS;
   }
   else
   {
-    setXMItem();
+    // default to MX...
+    items = items_MX;
+    the_number_of_item = COUNT_MX_ITEMS;
   }
 
-  return item;
+  return items;
 }
 
 ModelInfo* getModelInfo(uint16_t model_number)

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -151,10 +151,6 @@ void DynamixelTool::setControlTable(uint16_t model_number)
   the_number_of_item_ = getTheNumberOfControlItem();
   info_ptr_           = getModelInfo(model_number);
 
-  for (int index = 0; index < the_number_of_item_; index++)
-    item_[index] = item_ptr_[index];
-
-
   info_.velocity_to_value_ratio         = info_ptr_->velocity_to_value_ratio;
   info_.torque_to_current_value_ratio   = info_ptr_->torque_to_current_value_ratio;
 
@@ -380,17 +376,18 @@ uint8_t DynamixelTool::getTheNumberOfItem(void)
   return the_number_of_item_;
 }
 
-ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
+const ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
 {
-  static ControlTableItem* cti;    
-
+  const ControlTableItem* cti = item_ptr_;  
+  uint8_t name_length = strlen(item_name);
   for (int num = 0; num < the_number_of_item_; num++)
   {
-    if (!strncmp(item_name, item_[num].item_name, strlen(item_[num].item_name)))
+    if ((name_length == cti->item_name_length) && 
+        (memcmp(item_name, cti->item_name, name_length) == 0) )
     {
-      cti = &item_[num];
       return cti;
     }
+    cti++;
   }
 
   if (!strncmp(item_name, "Moving_Speed", strlen("Moving_Speed")))
@@ -401,9 +398,10 @@ ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
     getControlItem("Present_Speed");
   else if (!strncmp(item_name, "Present_Speed", strlen("Present_Speed")))
     getControlItem("Present_Velocity");
+  return NULL;
 }
 
-ControlTableItem* DynamixelTool::getControlItemPtr(void)
+const ControlTableItem* DynamixelTool::getControlItemPtr(void)
 {
   return item_ptr_;
 }

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
@@ -388,6 +388,7 @@ int32_t DynamixelWorkbench::itemRead(uint8_t id, const char* item_name)
 
   if (driver_.readRegister(id, item_name, &data))
     return data;
+  return 0; // Should decide on error value
 }
 
 int32_t  DynamixelWorkbench::itemRead(uint8_t id, uint16_t addr, uint8_t length)
@@ -396,6 +397,7 @@ int32_t  DynamixelWorkbench::itemRead(uint8_t id, uint16_t addr, uint8_t length)
 
   if (driver_.readRegister(id, addr, length, &data))
     return data; 
+  return 0; // Should decide on error value
 }
 
 int32_t* DynamixelWorkbench::syncRead(const char *item_name)
@@ -403,6 +405,7 @@ int32_t* DynamixelWorkbench::syncRead(const char *item_name)
   static int32_t data[16];
   if (driver_.syncRead(item_name, data))
     return data;
+  return 0; // Should decide on error value
 }
 
 int32_t DynamixelWorkbench::bulkRead(uint8_t id, const char* item_name)
@@ -410,6 +413,7 @@ int32_t DynamixelWorkbench::bulkRead(uint8_t id, const char* item_name)
   static int32_t data;
   if (driver_.bulkRead(id, item_name, &data))
     return data;
+  return 0; // Should decide on error value
 }
 
 void DynamixelWorkbench::addSyncWrite(const char* item_name)
@@ -621,4 +625,14 @@ void DynamixelWorkbench::millis(uint16_t msec)
 #else
     usleep(1000*msec);
 #endif
+}
+
+const ControlTableItem* DynamixelWorkbench::getControlItemPtr(uint8_t id)
+{
+  return driver_.getControlItemPtr(id);
+}
+
+uint8_t DynamixelWorkbench::getControlItemCount(uint8_t id)
+{
+  return driver_.getTheNumberOfItem(id);
 }


### PR DESCRIPTION
Currently on the OpenCM and OpenCR boards, the list of address names was restricted to a subset of the complete list that is part of this project.  This was due to memory usage.

So I changed how the control tables items were defined, in order to same RAM.  First off I defined them as const tables instead of having code set each one up.  As they are const structures, they are defined in ROM/Program space and do not consume RAM.  I also removed them from the Tool objects as since they were const objects the tools could simply keep the const pointer and again save that memory.

I also rearranged the items in the that structure to make all of the fields align to their correct boundaries, so the structure did not waste memory with fillers...  This saved lots of memory.

I also extracted the names out of each of the items, and created a set static const char variables for each unique name.  This saves memory on those systems that don't combine like strings into one.

With this I also added the length of the string to the ControlTableItem struct, as there was room for anohter byte to keep the correct alignement. This also removed the need to keep calling strlen() for each item in the list.

The code also compares the length of the string passed in versus the length of the item name and only if these match does a compare.  This should speed up the look up.

The code in the tool box area is identical to the changes I made in the OpenCM version, except the header file includes is different as OpenCM directory structure is different.

As I made the ControlTableItem tables const, and updated the API that returns it to also return const.  I had to update a couple of the other files in this project to make their variables that call this also be const.

Note this is related to the the Pull requests in both OpenCM and OpenCR projects which were closed.

https://github.com/ROBOTIS-GIT/OpenCR/pull/139
https://github.com/ROBOTIS-GIT/OpenCM9.04/pull/45

Testing:  Not sure best way to test the toolbox code.  
I did run some of the tutorial stuff in: http://emanual.robotis.com/docs/en/software/dynamixel/dynamixel_workbench/

And with the GUI I turned LED on/off, the Real time tick keeps showing different values...
