### PR TITLE
Reduce memory

### DIFF
--- a/dynamixel_workbench_single_manager/src/single_dynamixel_monitor.cpp
+++ b/dynamixel_workbench_single_manager/src/single_dynamixel_monitor.cpp
@@ -109,7 +109,7 @@ void SingleDynamixelMonitor::shutdownSingleDynamixelMonitor(void)
 
 void SingleDynamixelMonitor::initDynamixelStatePublisher()
 {
-  char* model_name = dynamixel_driver_->getModelName(dxl_id_);
+  const char* model_name = dynamixel_driver_->getModelName(dxl_id_);
 
   if (!strncmp(model_name, "AX", strlen("AX")))
   {
@@ -550,7 +550,7 @@ int main(int argc, char **argv)
 
 void SingleDynamixelMonitor::dynamixelStatePublish(void)
 {
-  char* model_name = dynamixel_driver_->getModelName(dxl_id_);
+  const char* model_name = dynamixel_driver_->getModelName(dxl_id_);
 
   if (!strncmp(model_name, "AX", strlen("AX")))
   {

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_driver.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_driver.h
@@ -82,7 +82,7 @@ class DynamixelDriver
 
   float getProtocolVersion(void);
   int getBaudrate(void);
-  char* getModelName(uint8_t id);
+  const char* getModelName(uint8_t id);
   uint16_t getModelNum(uint8_t id);
   const ControlTableItem* getControlItemPtr(uint8_t id);
   uint8_t getTheNumberOfItem(uint8_t id);

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
@@ -23,16 +23,11 @@
 
 #include "dynamixel_item.h"
 
-typedef struct
-{
-  uint8_t id;
-} DXLInfo;
-
 class DynamixelTool
 {
  public:
   enum {COUNT_DXL_INFO = 16};
-  DXLInfo dxl_info_[COUNT_DXL_INFO];
+  uint8_t dxl_id_[COUNT_DXL_INFO];
   uint8_t dxl_info_cnt_;
 
   const char *model_name_;

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
@@ -25,7 +25,7 @@
 
 typedef struct
 {
-  char model_name[20];
+  const char *model_name;
   uint16_t model_num;
   uint8_t id;
 } DXLInfo;

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_tool.h
@@ -25,16 +25,18 @@
 
 typedef struct
 {
-  const char *model_name;
-  uint16_t model_num;
   uint8_t id;
 } DXLInfo;
 
 class DynamixelTool
 {
  public:
-  DXLInfo dxl_info_[16];
+  enum {COUNT_DXL_INFO = 16};
+  DXLInfo dxl_info_[COUNT_DXL_INFO];
   uint8_t dxl_info_cnt_;
+
+  const char *model_name_;
+  uint16_t model_num_;
 
  private:
   const ControlTableItem* item_ptr_;

--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
@@ -56,7 +56,7 @@ class DynamixelWorkbench
   bool setPacketHandler(float protocol_version);
 
   float getProtocolVersion();
-  char* getModelName(uint8_t id);
+  const char* getModelName(uint8_t id);
 
   bool ledOn(uint8_t id);
   bool ledOff(uint8_t id);

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -415,7 +415,7 @@ bool DynamixelDriver::writeRegister(uint8_t id, const char *item_name, int32_t d
   const ControlTableItem *cti;
 
   uint8_t factor = getToolsFactor(id);
-  if (factor == 0xff) false; NULL;
+  if (factor == 0xff) return false; 
 
   cti = tools_[factor].getControlItem(item_name);
 

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -142,7 +142,7 @@ int DynamixelDriver::getBaudrate(void)
   return portHandler_->getBaudRate();
 }
 
-char *DynamixelDriver::getModelName(uint8_t id)
+const char *DynamixelDriver::getModelName(uint8_t id)
 {
   uint8_t factor = getToolsFactor(id);
 
@@ -312,7 +312,7 @@ bool DynamixelDriver::reset(uint8_t id)
           tools_[factor].dxl_info_[i].id = new_id;
       }
 
-      char* model_name = getModelName(new_id);
+      const char* model_name = getModelName(new_id);
       if (!strncmp(model_name, "AX", strlen("AX")) ||
           !strncmp(model_name, "MX-12W", strlen("MX-12W")))
         baud = 1000000;

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -26,7 +26,7 @@ DynamixelDriver::~DynamixelDriver()
   {
     for (int j = 0; j < tools_[i].dxl_info_cnt_; j++)
     {
-      writeRegister(tools_[i].dxl_info_[j].id, "Torque_Enable", false);
+      writeRegister(tools_[i].dxl_id_[j], "Torque_Enable", false);
     }
   }
 
@@ -160,7 +160,7 @@ uint16_t DynamixelDriver::getModelNum(uint8_t id)
 
   for (int i = 0; i < tools_[factor].dxl_info_cnt_; i++)
   {
-    if (tools_[factor].dxl_info_[i].id == id)
+    if (tools_[factor].dxl_id_[i] == id)
       return tools_[factor].model_num_;
   }
   return 0;
@@ -311,8 +311,8 @@ bool DynamixelDriver::reset(uint8_t id)
       if (factor == 0xff) return false;
       for (int i = 0; i < tools_[factor].dxl_info_cnt_; i++)
       {
-        if (tools_[factor].dxl_info_[i].id == id)
-          tools_[factor].dxl_info_[i].id = new_id;
+        if (tools_[factor].dxl_id_[i] == id)
+          tools_[factor].dxl_id_[i] = new_id;
       }
 
       const char* model_name = getModelName(new_id);
@@ -370,8 +370,8 @@ bool DynamixelDriver::reset(uint8_t id)
 
       for (int i = 0; i < tools_[factor].dxl_info_cnt_; i++)
       {
-        if (tools_[factor].dxl_info_[i].id == id)
-          tools_[factor].dxl_info_[i].id = new_id;
+        if (tools_[factor].dxl_id_[i] == id)
+          tools_[factor].dxl_id_[i] = new_id;
       }
 
       if (!strncmp(getModelName(new_id), "XL-320", strlen("XL-320")))
@@ -622,7 +622,7 @@ uint8_t DynamixelDriver::getToolsFactor(uint8_t id)
   {
     for (int j = 0; j < tools_[i].dxl_info_cnt_; j++)
     {
-      if (tools_[i].dxl_info_[j].id == id)
+      if (tools_[i].dxl_id_[j] == id)
       {
         return i;
       }
@@ -772,7 +772,7 @@ bool DynamixelDriver::syncWrite(const char *item_name, int32_t *data)
       data_byte[2] = DXL_LOBYTE(DXL_HIWORD(data[cnt]));
       data_byte[3] = DXL_HIBYTE(DXL_HIWORD(data[cnt]));
 
-      dxl_addparam_result = swh.groupSyncWrite->addParam(tools_[i].dxl_info_[j].id, (uint8_t *)&data_byte);
+      dxl_addparam_result = swh.groupSyncWrite->addParam(tools_[i].dxl_id_[j], (uint8_t *)&data_byte);
       if (dxl_addparam_result != true)
       {
         return false;
@@ -886,7 +886,7 @@ bool DynamixelDriver::syncRead(const char *item_name, int32_t *data)
   {
     for (int j = 0; j < tools_[i].dxl_info_cnt_; j++)
     {
-      dxl_addparam_result = srh.groupSyncRead->addParam(tools_[i].dxl_info_[j].id);
+      dxl_addparam_result = srh.groupSyncRead->addParam(tools_[i].dxl_id_[j]);
       if (dxl_addparam_result != true)
         return false;
     }
@@ -902,7 +902,7 @@ bool DynamixelDriver::syncRead(const char *item_name, int32_t *data)
   {
     for (int j = 0; j < tools_[i].dxl_info_cnt_; j++)
     {
-      uint8_t id = tools_[i].dxl_info_[j].id;
+      uint8_t id = tools_[i].dxl_id_[j];
 
       dxl_getdata_result = srh.groupSyncRead->isAvailable(id, srh.cti->address, srh.cti->data_length);
       if (dxl_getdata_result)

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -80,7 +80,7 @@ DynamixelTool::~DynamixelTool(){}
 
 void DynamixelTool::addTool(const char* model_name, uint8_t id)
 {
-  dxl_info_[dxl_info_cnt_].model_name = model_name;
+  model_name_ = model_name;
   setModelNum(model_name);
   dxl_info_[dxl_info_cnt_].id = id;
 
@@ -91,7 +91,7 @@ void DynamixelTool::addTool(const char* model_name, uint8_t id)
 void DynamixelTool::addTool(uint16_t model_number, uint8_t id)
 {
   setModelName(model_number);
-  dxl_info_[dxl_info_cnt_].model_num = model_number;
+  model_num_ = model_number;
   dxl_info_[dxl_info_cnt_].id = id;
 
   setControlTable(model_number);
@@ -100,7 +100,7 @@ void DynamixelTool::addTool(uint16_t model_number, uint8_t id)
 
 void DynamixelTool::addDXL(const char* model_name, uint8_t id)
 {
-  dxl_info_[dxl_info_cnt_].model_name =  model_name;
+  model_name_ = model_name;
   setModelNum(model_name);
   dxl_info_[dxl_info_cnt_].id = id;
 
@@ -110,7 +110,7 @@ void DynamixelTool::addDXL(const char* model_name, uint8_t id)
 void DynamixelTool::addDXL(uint16_t model_number, uint8_t id)
 {
   setModelName(model_number);
-  dxl_info_[dxl_info_cnt_].model_num = model_number;
+  model_num_ = model_number;
   dxl_info_[dxl_info_cnt_].id = id;
 
   dxl_info_cnt_++;
@@ -156,7 +156,7 @@ void DynamixelTool::setModelName(uint16_t model_number)
   {
     if (num == servo_num_to_name_table[index].model_number)
     {
-      dxl_info_[dxl_info_cnt_].model_name = servo_num_to_name_table[index].model_name;
+      model_name_ = servo_num_to_name_table[index].model_name;
       break;
     }
   }
@@ -169,9 +169,9 @@ void DynamixelTool::setModelNum(const char* model_name)
 
   for (uint8_t index=0; index < NUM_SERVO_NUM_TO_NAME; index++)
   {
-    if(strncmp(name, servo_num_to_name_table[index].model_name, name_length) == 0)
+    if(strncmp(name, model_name_, name_length) == 0)
     {
-      dxl_info_[dxl_info_cnt_].model_num = servo_num_to_name_table[index].model_number;
+      model_num_ = servo_num_to_name_table[index].model_number;
       break;
     }
   }

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -18,13 +18,69 @@
 
 #include "../../include/dynamixel_workbench_toolbox/dynamixel_tool.h"
 
+//===================================================================
+// Define Serial ID to Namd table
+//===================================================================
+typedef struct {
+  uint16_t      model_number;
+  const char *  model_name; 
+} SERVO_NUM_TO_NAME;
+
+static const SERVO_NUM_TO_NAME servo_num_to_name_table[] = {
+    {AX_12A, "AX-12A"},
+    {AX_12W, "AX-12W"},
+    {AX_18A, "AX-18A"},
+
+    {RX_10, "RX-10"},
+    {RX_24F, "RX-24F"},
+    {RX_28, "RX-28"},
+    {RX_64, "RX-64"},
+    {EX_106, "EX-106"},
+
+    {MX_12W, "MX-12W"},
+    {MX_28, "MX-28"},
+    {MX_28_2, "MX-28-2"},
+    {MX_64, "MX-64"},
+    {MX_64_2, "MX-64-2"},
+    {MX_106, "MX-106"},
+    {MX_106_2, "MX-106-2"},
+
+    {XL_320, "XL-320"},
+    {XL430_W250, "XL430-W250"},
+
+    {XM430_W210, "XM430-W210"},
+    {XM430_W350, "XM430-W350"},
+    {XM540_W150, "XM540-W150"},
+    {XM540_W270, "XM540-W270"},
+
+    {XH430_V210, "XH430-V210"},
+    {XH430_V350, "XH430-V350"},
+    {XH430_W210, "XH430-W210"},
+    {XH430_W350, "XH430-W350"},
+
+    {PRO_L42_10_S300_R, "PRO-L42-10-S300-R"},
+    {PRO_L54_30_S400_R, "PRO-L54-30-S400-R"},
+    {PRO_L54_30_S500_R, "PRO-L54-30-S500-R"},
+    {PRO_L54_50_S290_R, "PRO-L54-50-S290-R"},
+    {PRO_L54_50_S500_R, "PRO-L54-50-S500-R"},
+
+    {PRO_M42_10_S260_R, "PRO-M42-10-S260-R"},
+    {PRO_M54_40_S250_R, "PRO-M54-40-S250-R"},
+    {PRO_M54_60_S250_R, "PRO-M54-60-S250-R"},
+
+    {PRO_H42_20_S300_R, "PRO-H42-20-S300-R"},
+    {PRO_H54_100_S500_R, "PRO-H54-100-S500-R"},
+    {PRO_H54_200_S500_R, "PRO-H54-200-S500-R"}
+};
+#define NUM_SERVO_NUM_TO_NAME  (sizeof(servo_num_to_name_table)/sizeof(servo_num_to_name_table[0]))
+
 DynamixelTool::DynamixelTool() : dxl_info_cnt_(0), the_number_of_item_(0){}
 
 DynamixelTool::~DynamixelTool(){}
 
 void DynamixelTool::addTool(const char* model_name, uint8_t id)
 {
-  strcpy(dxl_info_[dxl_info_cnt_].model_name, model_name);
+  dxl_info_[dxl_info_cnt_].model_name = model_name;
   setModelNum(model_name);
   dxl_info_[dxl_info_cnt_].id = id;
 
@@ -44,7 +100,7 @@ void DynamixelTool::addTool(uint16_t model_number, uint8_t id)
 
 void DynamixelTool::addDXL(const char* model_name, uint8_t id)
 {
-  strcpy(dxl_info_[dxl_info_cnt_].model_name, model_name);
+  dxl_info_[dxl_info_cnt_].model_name =  model_name;
   setModelNum(model_name);
   dxl_info_[dxl_info_cnt_].id = id;
 
@@ -63,86 +119,16 @@ void DynamixelTool::addDXL(uint16_t model_number, uint8_t id)
 void DynamixelTool::setControlTable(const char *model_name)
 {  
   const char* name = model_name;
+  uint8_t name_length = strlen(name);
 
-  if (!strncmp(name, "AX-12A", strlen(name))) 
-    setControlTable(AX_12A);
-  else if (!strncmp(name, "AX-12W", strlen(name)))
-    setControlTable(AX_12W);
-  else if (!strncmp(name, "AX-18A", strlen(name)))
-    setControlTable(AX_18A);
-
-  else if (!strncmp(name, "RX-24F", strlen(name)))
-    setControlTable(RX_24F);
-  else if (!strncmp(name, "RX-28", strlen(name)))
-    setControlTable(RX_28);
-  else if (!strncmp(name, "RX-64", strlen(name)))
-    setControlTable(RX_64);
-
-  else if (!strncmp(name, "EX-106", strlen(name)))
-    setControlTable(EX_106);
-
-  else if (!strncmp(name, "MX-12W", strlen(name)))
-    setControlTable(MX_12W);
-  else if (!strncmp(name, "MX-28", strlen(name)))
-    setControlTable(MX_28);
-  else if (!strncmp(name, "MX-28-2", strlen(name)))
-    setControlTable(MX_28_2);
-  else if (!strncmp(name, "MX-64", strlen(name)))
-    setControlTable(MX_64);
-  else if (!strncmp(name, "MX-64-2", strlen(name)))
-    setControlTable(MX_64_2);
-  else if (!strncmp(name, "MX-106", strlen(name)))
-    setControlTable(MX_106);
-  else if (!strncmp(name, "MX-106-2", strlen(name)))
-    setControlTable(MX_106_2);
-
-  else if (!strncmp(name, "XL-320", strlen(name)))
-    setControlTable(XL_320);
-  else if (!strncmp(name, "XL430-W250", strlen(name)))
-    setControlTable(XL430_W250);
-
-  else if (!strncmp(name, "XM430-W210", strlen(name)))
-    setControlTable(XM430_W210);
-  else if (!strncmp(name, "XM430-W350", strlen(name)))
-    setControlTable(XM430_W350);
-  else if (!strncmp(name, "XM540-W150", strlen(name)))
-    setControlTable(XM540_W150);
-  else if (!strncmp(name, "XM540-W270", strlen(name)))
-    setControlTable(XM540_W270);
-
-  else if (!strncmp(name, "XH430-V210", strlen(name)))
-    setControlTable(XH430_V210);
-  else if (!strncmp(name, "XH430-V350", strlen(name)))
-    setControlTable(XH430_V350);
-  else if (!strncmp(name, "XH430-W210", strlen(name)))
-    setControlTable(XH430_W210);
-  else if (!strncmp(name, "XH430-W350", strlen(name)))
-    setControlTable(XH430_W350);
-
-  else if (!strncmp(name, "PRO-L42-10-S300-R", strlen(name)))
-    setControlTable(PRO_L42_10_S300_R);
-  else if (!strncmp(name, "PRO-L54-30-S400-R", strlen(name)))
-    setControlTable(PRO_L54_30_S400_R);
-  else if (!strncmp(name, "PRO-L54-30-S500-R", strlen(name)))
-    setControlTable(PRO_L54_30_S500_R);
-  else if (!strncmp(name, "PRO-L54-50-S290-R", strlen(name)))
-    setControlTable(PRO_L54_50_S290_R);
-  else if (!strncmp(name, "PRO-L54-50-S500-R", strlen(name)))
-    setControlTable(PRO_L54_50_S500_R);
-
-  else if (!strncmp(name, "PRO-M42-10-S260-R", strlen(name)))
-    setControlTable(PRO_M42_10_S260_R);
-  else if (!strncmp(name, "PRO-M54-40-S250-R", strlen(name)))
-    setControlTable(PRO_M54_40_S250_R);
-  else if (!strncmp(name, "PRO-M54-60-S250-R", strlen(name)))
-    setControlTable(PRO_M54_60_S250_R);
-
-  else if (!strncmp(name, "PRO-H42-20-S300-R", strlen(name)))
-    setControlTable(PRO_H42_20_S300_R);
-  else if (!strncmp(name, "PRO-H54-100-S500-R", strlen(name)))
-    setControlTable(PRO_H54_100_S500_R);
-  else if (!strncmp(name, "PRO-H54-200-S500-R", strlen(name)))
-    setControlTable(PRO_H54_200_S500_R);
+  for (uint8_t index=0; index < NUM_SERVO_NUM_TO_NAME; index++)
+  {
+    if(strncmp(name, servo_num_to_name_table[index].model_name, name_length) == 0)
+    {
+      setControlTable(servo_num_to_name_table[index].model_number);
+      break;
+    }
+  }
 }
 
 void DynamixelTool::setControlTable(uint16_t model_number)
@@ -166,174 +152,30 @@ void DynamixelTool::setModelName(uint16_t model_number)
 {
   uint16_t num = model_number;
 
-  if (num == AX_12A)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "AX-12A");
-  else if (num == AX_12W)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "AX-12W");
-  else if (num == AX_18A)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "AX-18A");
-
-  else if (num == RX_10)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "RX-10");
-  else if (num == RX_24F)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "RX-24F");
-  else if (num == RX_28)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "RX-28");
-  else if (num == RX_64)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "RX-64");
-
-  else if (num == EX_106)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "EX-106");
-
-  else if (num == MX_12W)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-12W");
-  else if (num == MX_28)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-28");
-  else if (num == MX_28_2)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-28-2");
-  else if (num == MX_64)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-64");
-  else if (num == MX_64_2)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-64-2");
-  else if (num == MX_106)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-106");
-  else if (num == MX_106_2)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "MX-106-2");
-
-  else if (num == XL_320)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XL-320");
-  else if (num == XL430_W250)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XL430-W250");
-
-  else if (num == XM430_W210)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XM430-W210");
-  else if (num == XM430_W350)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XM430-W350");
-  else if (num == XM540_W150)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XM540-W150");
-  else if (num == XM540_W270)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XM540-W270");
-
-  else if (num == XH430_V210)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XH430-V210");
-  else if (num == XH430_V350)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XH430-V350");
-  else if (num == XH430_W210)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XH430-W210");
-  else if (num == XH430_W350)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "XH430-W350");
-
-  else if (num == PRO_L42_10_S300_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-L42-10-S300-R");
-  else if (num == PRO_L54_30_S400_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-L54-30-S400-R");
-  else if (num == PRO_L54_30_S500_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-L54-30-S500-R");
-  else if (num == PRO_L54_50_S290_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-L54-50-S290-R");
-  else if (num == PRO_L54_50_S500_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-L54-50-S500-R");
-
-  else if (num == PRO_M42_10_S260_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-M42-10-S260-R");
-  else if (num == PRO_M54_40_S250_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-M54-40-S250-R");
-  else if (num == PRO_M54_60_S250_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-M54-60-S250-R");
-
-  else if (num == PRO_H42_20_S300_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-H42-20-S300-R");
-  else if (num == PRO_H54_100_S500_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-H54-100-S500-R");
-  else if (num == PRO_H54_200_S500_R)
-    strcpy(dxl_info_[dxl_info_cnt_].model_name, "PRO-H54-200-S500-R");
+  for (uint8_t index=0; index < NUM_SERVO_NUM_TO_NAME; index++)
+  {
+    if (num == servo_num_to_name_table[index].model_number)
+    {
+      dxl_info_[dxl_info_cnt_].model_name = servo_num_to_name_table[index].model_name;
+      break;
+    }
+  }
 }
 
 void DynamixelTool::setModelNum(const char* model_name)
 {
   const char* name = model_name;
+  uint8_t name_length = strlen(name);
 
-  if (!strncmp(name, "AX-12A", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = AX_12A;
-  else if (!strncmp(name, "AX-12W", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = AX_12W;
-  else if (!strncmp(name, "AX-18A", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = AX_18A;
+  for (uint8_t index=0; index < NUM_SERVO_NUM_TO_NAME; index++)
+  {
+    if(strncmp(name, servo_num_to_name_table[index].model_name, name_length) == 0)
+    {
+      dxl_info_[dxl_info_cnt_].model_num = servo_num_to_name_table[index].model_number;
+      break;
+    }
+  }
 
-  else if (!strncmp(name, "RX-10", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = RX_10;
-  else if (!strncmp(name, "RX-24F", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = RX_24F;
-  else if (!strncmp(name, "RX-28", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = RX_28;
-  else if (!strncmp(name, "RX-64", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = RX_64;
-
-  else if (!strncmp(name, "EX-106", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = EX_106;
-
-  else if (!strncmp(name, "MX-12W", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_12W;
-  else if (!strncmp(name, "MX-28", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_28;
-  else if (!strncmp(name, "MX-28-2", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_28_2;
-  else if (!strncmp(name, "MX-64", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_64;
-  else if (!strncmp(name, "MX-64-2", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_64_2;
-  else if (!strncmp(name, "MX-106", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_106;
-  else if (!strncmp(name, "MX-106-2", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = MX_106_2;
-
-  else if (!strncmp(name, "XL-320", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XL_320;
-  else if (!strncmp(name, "XL430-W250", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XL430_W250;
-
-  else if (!strncmp(name, "XM430-W210", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XM430_W210;
-  else if (!strncmp(name, "XM430-W350", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XM430_W350;
-  else if (!strncmp(name, "XM540-W150", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XM540_W150;
-  else if (!strncmp(name, "XM540-W270", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XM540_W270;
-
-  else if (!strncmp(name, "XH430-V210", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XH430_V210;
-  else if (!strncmp(name, "XH430-V350", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XH430_V350;
-  else if (!strncmp(name, "XH430-W210", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XH430_W210;
-  else if (!strncmp(name, "XH430-W350", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = XH430_W350;
-
-  else if (!strncmp(name, "PRO-L42-10-S300-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_L42_10_S300_R;
-  else if (!strncmp(name, "PRO-L54-30-S400-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_L54_30_S400_R;
-  else if (!strncmp(name, "PRO-L54-30-S500-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_L54_30_S500_R;
-  else if (!strncmp(name, "PRO-L54-50-S290-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_L54_50_S290_R;
-  else if (!strncmp(name, "PRO-L54-50-S500-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_L54_50_S500_R;
-
-  else if (!strncmp(name, "PRO-M42-10-S260-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_M42_10_S260_R;
-  else if (!strncmp(name, "PRO-M54-40-S250-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_M54_40_S250_R;
-  else if (!strncmp(name, "PRO-M54-60-S250-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_M54_60_S250_R;
-
-  else if (!strncmp(name, "PRO-H42-20-S300-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_H42_20_S300_R;
-  else if (!strncmp(name, "PRO-H54-100-S500-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_H54_100_S500_R;
-  else if (!strncmp(name, "PRO-H54-200-S500-R", strlen(name)))
-    dxl_info_[dxl_info_cnt_].model_num = PRO_H54_200_S500_R;
 }
 
 float DynamixelTool::getVelocityToValueRatio(void)

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -82,7 +82,7 @@ void DynamixelTool::addTool(const char* model_name, uint8_t id)
 {
   model_name_ = model_name;
   setModelNum(model_name);
-  dxl_info_[dxl_info_cnt_].id = id;
+  dxl_id_[dxl_info_cnt_] = id;
 
   setControlTable(model_name);
   dxl_info_cnt_++;
@@ -92,7 +92,7 @@ void DynamixelTool::addTool(uint16_t model_number, uint8_t id)
 {
   setModelName(model_number);
   model_num_ = model_number;
-  dxl_info_[dxl_info_cnt_].id = id;
+  dxl_id_[dxl_info_cnt_] = id;
 
   setControlTable(model_number);
   dxl_info_cnt_++;
@@ -102,7 +102,7 @@ void DynamixelTool::addDXL(const char* model_name, uint8_t id)
 {
   model_name_ = model_name;
   setModelNum(model_name);
-  dxl_info_[dxl_info_cnt_].id = id;
+  dxl_id_[dxl_info_cnt_] = id;
 
   dxl_info_cnt_++;
 }
@@ -111,7 +111,7 @@ void DynamixelTool::addDXL(uint16_t model_number, uint8_t id)
 {
   setModelName(model_number);
   model_num_ = model_number;
-  dxl_info_[dxl_info_cnt_].id = id;
+  dxl_id_[dxl_info_cnt_] = id;
 
   dxl_info_cnt_++;
 }

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
@@ -153,7 +153,7 @@ float DynamixelWorkbench::getProtocolVersion()
   return driver_.getProtocolVersion();
 }
 
-char* DynamixelWorkbench::getModelName(uint8_t id)
+const char* DynamixelWorkbench::getModelName(uint8_t id)
 {
   return driver_.getModelName(id);
 }


### PR DESCRIPTION
Warning, I still need to do additional testing, but would be great if you could verify that some of the assumptions I have done are OK and that it works for you.

The main reason I started playing with this, is to trying to see about reducing the memory usage. 
I updated an Arduino sketch and added:
```
Serial.print("Size of DynamixelWorkbench: "); Serial.println(sizeof(DynamixelWorkbench), DEC);
```
And it printed 2312. 

Which if you are on a reduced memory board, feels like a lot.  

So looked through code and found that I believe for each "Tool" it is setup to handle one Servo_type,  but you are storing the Servo type in every Item... Also you were storing 20 byte Servo type strings for each of these servos.  so (20+2)*(16*5) bytes to hold the names and servo types. 

I changed this to store the device type in the tool and I pointer to const string in the tool as well.  I also changed the mapping of Servo type number to string or string to type into a const table... 

So with these changes the size now prints out as 512.

Also as I reported in issue #189  there is a problem that each of these tools can only handle 16 servos. 

So I added checks in the code that if you are trying to add a new ID and the tool that is setup for this type is full, it tries to allocate another tool and continue in that one...    Note: I am also only comparing by model number and not doing string compares as I think again these is a 1 to 1 mapping. 

I need to do more testing with my hexapod, but looks like some of the wiring is needing to be updated so not all of them are reporting.  

I may also find other places that assumed max of 16... 

Let me know what you think.  I have the same change with a new branch up for OpenCM.  Have not done OpenCR yet, but should be straight copy of the files from this project. 

Kurt