### PR TITLE
Comment out unnecessary torque on after reading .yaml file.

### DIFF
--- a/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
+++ b/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
@@ -147,7 +147,7 @@ bool DynamixelController::initDynamixels(void)
       }
     }
 
-    dxl_wb_->torqueOn((uint8_t)dxl.second);
+    // dxl_wb_->torqueOn((uint8_t)dxl.second);
   }
 
   return true;


### PR DESCRIPTION
Related to #248 

I commented out unnecessary torque on after reading .yaml file.

The code turn on torque after reading torque off setting from the yaml file.