### PR TITLE
initialize velocity and acceleration of goal waypoint

### DIFF
--- a/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
+++ b/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
@@ -285,6 +285,8 @@ bool DynamixelController::getPresentPosition(std::vector<std::string> dxl_name)
       for(uint8_t index = 0; index < id_cnt; index++)
       {
         wp.position = dxl_wb_->convertValue2Radian(id_array[index], get_position[index]);
+        wp.velocity = 0.0f;
+        wp.acceleration = 0.0f;
         pre_goal_.push_back(wp);
       }
     }
@@ -306,6 +308,8 @@ bool DynamixelController::getPresentPosition(std::vector<std::string> dxl_name)
       }
 
       wp.position = dxl_wb_->convertValue2Radian((uint8_t)dxl.second, read_position);
+      wp.velocity = 0.0f;
+      wp.acceleration = 0.0f;
       pre_goal_.push_back(wp);
     }
   }


### PR DESCRIPTION
In `getPresentPosition()` in dynamixel_workbench_controllers.cpp, `wp.velocity` and `wp.acceleration` are not initialized.

This causes unstable value of goal velocity and acceleration. 
(In my environment, these are sometimes initialized as 0, and other times initialized as very big number.)

Cc @mmurooka