### PR TITLE
Reduce warning log when publishing JointTrajectory

### DIFF
--- a/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
+++ b/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
@@ -732,7 +732,7 @@ void DynamixelController::trajectoryMsgCallback(const trajectory_msgs::JointTraj
   }
   else
   {
-    ROS_WARN("Dynamixel is moving");
+    ROS_INFO_THROTTLE(1, "Dynamixel is moving");
   }
 }
 


### PR DESCRIPTION
When a node publishes `JointTrajectory` messages, the `dynamixel_workbench_controller` logs `Dynamixel is moving` with waring level everytime.
It seems to be too much and the level also seems to be too high. This PR simply fixed them.