### PR TITLE
Fix bug introduced in 37970b9

### DIFF
--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
@@ -1497,7 +1497,7 @@ const ModelInfo *DynamixelItem::getModelInfo(uint16_t model_number)
   {
     info = &info_EXTXH;
   }
-  else if (num == XW540_T260 || XW540_T140)
+  else if (num == XW540_T260 || num == XW540_T140)
   {
     info = &info_XW;
   }


### PR DESCRIPTION
This bug caused DynamixelItem::getModelInfo to always return info_XW if it reached that point in code, affecting alll PRO models and grippers.