### PR TITLE
Add 2XC430-W250 support for ROS 2

### DIFF
--- a/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_item.h
+++ b/dynamixel_workbench_toolbox/include/dynamixel_workbench_toolbox/dynamixel_item.h
@@ -45,6 +45,7 @@
 #define XL430_W250 1060
 
 #define XL430_W250_2 1090 // 2XL
+#define XC430_W250_2 1160 // 2XC
 
 #define XC430_W150 1070
 #define XC430_W240 1080

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
@@ -533,7 +533,7 @@ static const ModelInfo info_XL320 = {0.11,
                                   2.61799};
 
 //---------------------------------------------------------
-// XL - (num == XL430_W250, XL430_W250_2, XC430_W150, XC430_W240)
+// XL - (num == XL430_W250, XL430_W250_2, XC430_W150, XC430_W240, XC430_W250_2)
 //---------------------------------------------------------
 static const ControlItem items_XL[]{
     {s_Model_Number, 0, sizeof(s_Model_Number) - 1, 2},
@@ -1301,7 +1301,7 @@ const ControlItem *DynamixelItem::getControlTable(uint16_t model_number)
     control_table = items_XL320;
     the_number_of_item = COUNT_XL320_ITEMS;
   }
-  else if (num == XL430_W250 || num == XL430_W250_2 || num == XC430_W150 || num == XC430_W240)
+  else if (num == XL430_W250 || num == XL430_W250_2 || num == XC430_W150 || num == XC430_W240 || num == XC430_W250_2)
   {
     control_table = items_XL;
     the_number_of_item = COUNT_XL_ITEMS;
@@ -1407,7 +1407,7 @@ const ModelInfo *DynamixelItem::getModelInfo(uint16_t model_number)
   {
     info = &info_XL320;
   }
-  else if (num == XL430_W250 || num == XL430_W250_2 || num == XC430_W150 || num == XC430_W240)
+  else if (num == XL430_W250 || num == XL430_W250_2 || num == XC430_W150 || num == XC430_W240 || num == XC430_W250_2)
   {
     info = &info_XL;
   }

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -51,6 +51,7 @@ static const DynamixelModel dynamixel_model_table[] = {
     {XL430_W250, "XL430-W250"},
 
     {XL430_W250_2, "XL430-W250-2"}, // 2XL
+    {XC430_W250_2, "XC430-W250-2"}, // 2XC
 
     {XC430_W150, "XC430-W150"},
     {XC430_W240, "XC430-W240"},


### PR DESCRIPTION
It's the backport of #330 to support 2XC430-W250 model for ROS 2. It works fine.