### PR TITLE
fix variable length warning using std::vector

### DIFF
--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -16,6 +16,7 @@
 
 /* Authors: Taehun Lim (Darby) */
 
+#include <memory>
 #include "../../include/dynamixel_workbench_toolbox/dynamixel_driver.h"
 
 DynamixelDriver::DynamixelDriver() : tools_cnt_(0), 
@@ -773,13 +774,13 @@ bool DynamixelDriver::readRegister(uint8_t id, uint16_t address, uint16_t length
 {
   ErrorFromSDK sdk_error = {0, false, false, 0};
   
-  uint8_t data_read[length];
+  std::vector<uint8_t> data_read(length);
 
   sdk_error.dxl_comm_result = packetHandler_->readTxRx(portHandler_, 
                                                       id, 
                                                       address,
                                                       length, 
-                                                      (uint8_t *)&data_read, 
+                                                      data_read.data(), 
                                                       &sdk_error.dxl_error);
   if (sdk_error.dxl_comm_result != COMM_SUCCESS)
   {
@@ -1009,7 +1010,7 @@ bool DynamixelDriver::syncWrite(uint8_t index, uint8_t *id, uint8_t id_num, int3
   ErrorFromSDK sdk_error = {0, false, false, 0};
 
   uint8_t parameter[4] = {0, 0, 0, 0};
-  uint8_t multi_parameter[4*data_num_for_each_id];
+  std::vector<uint8_t> multi_parameter(4*data_num_for_each_id);
   uint8_t cnt = 0;
 
   for (int i = 0; i < id_num; i++)
@@ -1023,7 +1024,7 @@ bool DynamixelDriver::syncWrite(uint8_t index, uint8_t *id, uint8_t id_num, int3
       }
     }
 
-    sdk_error.dxl_addparam_result = syncWriteHandler_[index].groupSyncWrite->addParam(id[i], (uint8_t *)&multi_parameter);
+    sdk_error.dxl_addparam_result = syncWriteHandler_[index].groupSyncWrite->addParam(id[i], multi_parameter.data());
     if (sdk_error.dxl_addparam_result != true)
     {
       if (log != NULL) *log = "groupSyncWrite addparam failed";


### PR DESCRIPTION
Resolves: https://github.com/ROBOTIS-GIT/DynamixelSDK/issues/553

Gets rid of the following warning:

```
Starting >>> dynamixel_workbench_toolbox
--- stderr: dynamixel_workbench_toolbox                              
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel-workbench/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp: In member function ‘bool DynamixelDriver::readRegister(uint8_t, uint16_t, uint16_t, uint32_t*, const char**)’:
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel-workbench/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp:776:11: warning: ISO C++ forbids variable length array ‘data_read’ [-Wvla]
  776 |   uint8_t data_read[length];
      |           ^~~~~~~~~
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel-workbench/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp: In member function ‘bool DynamixelDriver::syncWrite(uint8_t, uint8_t*, uint8_t, int32_t*, uint8_t, const char**)’:
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel-workbench/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp:1012:11: warning: ISO C++ forbids variable length array ‘multi_parameter’ [-Wvla]
 1012 |   uint8_t multi_parameter[4*data_num_for_each_id];
      |           ^~~~~~~~~~~~~~~
---
```