### PR TITLE
allow dynamixel_info to be sent as an argument when including this launch file

### DIFF
--- a/dynamixel_workbench_controllers/launch/dynamixel_controllers.launch
+++ b/dynamixel_workbench_controllers/launch/dynamixel_controllers.launch
@@ -6,8 +6,10 @@
   <arg name="use_moveit"              default="false"/>
   <arg name="use_joint_state"         default="true"/>
   <arg name="use_cmd_vel"             default="false"/>
+  <arg name="dynamixel_info"          default="$(find dynamixel_workbench_controllers)/config/basic.yaml"/>                      
+ 
+  <param name="dynamixel_info"        value="$(arg dynamixel_info)"/>
 
-  <param name="dynamixel_info"          value="$(find dynamixel_workbench_controllers)/config/basic.yaml"/>
 
   <node name="$(arg namespace)" pkg="dynamixel_workbench_controllers" type="dynamixel_workbench_controllers"
         required="true" output="screen" args="$(arg usb_port) $(arg dxl_baud_rate)">


### PR DESCRIPTION
Currently, one way to launch the dynamixel workbench controllers is to copy-paste this launch file and along with furnishing necessary arguments, edit the dynamixel_info param value to reflect your particular yaml file. With my proposed change, dynamixel_info becomes an optional argument with default as the basic.yaml demo file. Then, to launch the controllers, instead of copy-pasting the whole thing, all you have to do is include this launch file in your project launch file and supply the desired arguments (including the param file) as shown in the example below. This tremendously increases the reusability of this launch file and package instead of having to reinvent the wheel. Thanks!
```xml
<launch>                                                                                                                                                                                                                                                                          
  <arg name="usb_port"                default="/dev/ttyUSB0"/>                                                                           
  <arg name="dxl_baud_rate"           default="1000000"/>                                                                                
  <arg name="namespace"               default="dynamixel_workbench"/>                                                                    
  <arg name="dynamixel_info"          default="$(find cyton_gamma_1500_control)/config/cyton_gamma_1500_motor_config.yaml"/>             
                                                                                                                                         
  <include file="$(find dynamixel_workbench_controllers)/launch/dynamixel_controllers.launch">                                           
  <arg name="usb_port"                value="$(arg usb_port)"/>                                                                          
  <arg name="dxl_baud_rate"           value="$(arg dxl_baud_rate)"/>                                                                     
  <arg name="namespace"               value="$(arg namespace)"/>                                                                         
  <arg name="dynamixel_info"          value="$(arg dynamixel_info)"/>                                                                    
  </include>                                                                                                                             
</launch>  
```