### PR TITLE
Fix the 'Failed to get speed' error message in workbench.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![melodic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/melodic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/melodic-devel)
 [![noetic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/noetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/noetic-devel)
 
+[![foxy-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/foxy-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/foxy-devel)
+[![galactic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/galactic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/galactic-devel)
+[![humble-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/humble-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/humble-devel)
+[![ROS2 Rolling Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/ros2-ci/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/ros2)
+
 ## ROBOTIS e-Manual for Dynamixel Workbench
 - [ROBOTIS e-Manual for Dynamixel Workbench](http://emanual.robotis.com/docs/en/software/dynamixel/dynamixel_workbench/)
 

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
@@ -1191,6 +1191,14 @@ bool DynamixelWorkbench::getPresentVelocityData(uint8_t id, int32_t* data, const
     return result;
   }
 
+  // some protocols has Present_velocity for getSpeed. 
+  result = readRegister(id, "Present_Velocity", &get_data, log);
+  if (result == false)
+  {
+    if (log != NULL) *log = "[DynamixelWorkbench] Failed to get present speed data!";
+    return result;
+  }
+
   *data = get_data;
   if (log != NULL) *log = "[DynamixelWorkbench] Succeeded to get present speed data!";
   return result;


### PR DESCRIPTION
Some of the motor's protocols has "Present_Velocity" instead of "Present_Speed" and that results in Failed to get present speed. This commit checks for both options before returning the present speed.