### PR TITLE
Enable to change required and respawn of dynamixel_workbench_controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![melodic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/melodic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/melodic-devel)
 [![noetic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/noetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/noetic-devel)
 
+[![foxy-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/foxy-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/foxy-devel)
+[![galactic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/galactic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/galactic-devel)
+[![humble-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/humble-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/humble-devel)
+[![ROS2 Rolling Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/ros2-ci/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/ros2)
+
 ## ROBOTIS e-Manual for Dynamixel Workbench
 - [ROBOTIS e-Manual for Dynamixel Workbench](http://emanual.robotis.com/docs/en/software/dynamixel/dynamixel_workbench/)
 

--- a/dynamixel_workbench_controllers/launch/dynamixel_controllers.launch
+++ b/dynamixel_workbench_controllers/launch/dynamixel_controllers.launch
@@ -2,6 +2,8 @@
   <arg name="usb_port"                default="/dev/ttyUSB0"/>
   <arg name="dxl_baud_rate"           default="57600"/>
   <arg name="namespace"               default="dynamixel_workbench"/>
+  <arg name="required"                default="true"/>
+  <arg name="respawn"                 default="false"/>
 
   <arg name="use_moveit"              default="false"/>
   <arg name="use_joint_state"         default="true"/>
@@ -10,7 +12,7 @@
   <param name="dynamixel_info"          value="$(find dynamixel_workbench_controllers)/config/basic.yaml"/>
 
   <node name="$(arg namespace)" pkg="dynamixel_workbench_controllers" type="dynamixel_workbench_controllers"
-        required="true" output="screen" args="$(arg usb_port) $(arg dxl_baud_rate)">
+        required="$(arg required)" respawn="$(arg respawn)" output="screen" args="$(arg usb_port) $(arg dxl_baud_rate)">
     <param name="use_moveit"              value="$(arg use_moveit)"/>
     <param name="use_joint_states_topic"  value="$(arg use_joint_state)"/>
     <param name="use_cmd_vel_topic"       value="$(arg use_cmd_vel)"/>


### PR DESCRIPTION
We sometimes want to respawn `dynamixel_workbench_controllers` until dynamixel motors are correctly connected.
With this PR, we can select that behavior by passing `required:=false respawn:=true` to `dynamixel_controllers.launch`.
This PR does not change the default behavior.

cc @iory