### PR TITLE
[dynamixel_workbench_controllers] Enable to torque off on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![melodic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/melodic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/melodic-devel)
 [![noetic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/noetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/noetic-devel)
 
+[![foxy-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/foxy-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/foxy-devel)
+[![galactic-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/galactic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/galactic-devel)
+[![humble-devel Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/humble-devel/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/humble-devel)
+[![ROS2 Rolling Status](https://github.com/ROBOTIS-GIT/dynamixel-workbench/workflows/ros2-ci/badge.svg)](https://github.com/ROBOTIS-GIT/dynamixel-workbench/tree/ros2)
+
 ## ROBOTIS e-Manual for Dynamixel Workbench
 - [ROBOTIS e-Manual for Dynamixel Workbench](http://emanual.robotis.com/docs/en/software/dynamixel/dynamixel_workbench/)
 

--- a/dynamixel_workbench_controllers/include/dynamixel_workbench_controllers/dynamixel_workbench_controllers.h
+++ b/dynamixel_workbench_controllers/include/dynamixel_workbench_controllers/dynamixel_workbench_controllers.h
@@ -84,6 +84,7 @@ class DynamixelController
   bool is_joint_state_topic_;
   bool is_cmd_vel_topic_;
   bool use_moveit_;
+  bool torque_off_on_shutdown_;
 
   double wheel_separation_;
   double wheel_radius_;
@@ -126,6 +127,8 @@ class DynamixelController
   void trajectoryMsgCallback(const trajectory_msgs::JointTrajectory::ConstPtr &msg);
   bool dynamixelCommandMsgCallback(dynamixel_workbench_msgs::DynamixelCommand::Request &req,
                                    dynamixel_workbench_msgs::DynamixelCommand::Response &res);
+
+  void onShutdown(void);
 };
 
 #endif //DYNAMIXEL_WORKBENCH_CONTROLLERS_H

--- a/dynamixel_workbench_controllers/launch/dynamixel_controllers.launch
+++ b/dynamixel_workbench_controllers/launch/dynamixel_controllers.launch
@@ -6,6 +6,7 @@
   <arg name="use_moveit"              default="false"/>
   <arg name="use_joint_state"         default="true"/>
   <arg name="use_cmd_vel"             default="false"/>
+  <arg name="torque_off_on_shutdown"  default="false"/>
 
   <param name="dynamixel_info"          value="$(find dynamixel_workbench_controllers)/config/basic.yaml"/>
 
@@ -14,6 +15,7 @@
     <param name="use_moveit"              value="$(arg use_moveit)"/>
     <param name="use_joint_states_topic"  value="$(arg use_joint_state)"/>
     <param name="use_cmd_vel_topic"       value="$(arg use_cmd_vel)"/>
+    <param name="torque_off_on_shutdown"  value="$(arg torque_off_on_shutdown)"/>
     <rosparam>
       publish_period: 0.010
       dxl_read_period: 0.010


### PR DESCRIPTION
We sometimes want to disable torque of dynamixel motors when `dynamixel_workbench_controllers` is killed in order not to leave the motors torque on and overheat them.
With this PR, we can select that behavior by passing `torque_off_on_shutdown:=true` to `dynamixel_controllers.launch`.
This PR does not change the default behavior.