### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/dynamixel_workbench_toolbox/CMakeLists.txt
+++ b/dynamixel_workbench_toolbox/CMakeLists.txt
@@ -49,7 +49,7 @@ add_library(${LIB_NAME} SHARED
   src/${PROJECT_NAME}/dynamixel_tool.cpp
   src/${PROJECT_NAME}/dynamixel_workbench.cpp
 )
-ament_target_dependencies(${LIB_NAME} ${dependencies_lib})
+target_link_libraries(${LIB_NAME} PUBLIC ${dependencies_lib})
 
 ################################################################################
 # Install


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
