### PR TITLE
use modern cmake to do target-based installation

### DIFF
--- a/dynamixel_workbench_toolbox/CMakeLists.txt
+++ b/dynamixel_workbench_toolbox/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 ################################################################################
 find_package(ament_cmake REQUIRED)
 find_package(dynamixel_sdk REQUIRED)
-find_package(rclcpp REQUIRED)
 
 ################################################################################
 # Declare ROS messages, services and actions
@@ -32,14 +31,6 @@ find_package(rclcpp REQUIRED)
 ################################################################################
 # Build
 ################################################################################
-include_directories(
-  include
-)
-
-set(dependencies_lib
-  "dynamixel_sdk"
-  "rclcpp"
-)
 
 set(LIB_NAME "dynamixel_workbench_toolbox")
 
@@ -49,19 +40,28 @@ add_library(${LIB_NAME} SHARED
   src/${PROJECT_NAME}/dynamixel_tool.cpp
   src/${PROJECT_NAME}/dynamixel_workbench.cpp
 )
-ament_target_dependencies(${LIB_NAME} ${dependencies_lib})
+target_include_directories(${LIB_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  ${dynamixel_sdk_INCLUDE_DIRS}
+)
+
+target_link_libraries(${LIB_NAME} PUBLIC
+  ${dynamixel_sdk_LIBRARIES}
+)
 
 ################################################################################
 # Install
 ################################################################################
 install(TARGETS ${LIB_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin/${PROJECT_NAME}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 ################################################################################
@@ -71,8 +71,6 @@ install(DIRECTORY include/
 ################################################################################
 # Macro for ament package
 ################################################################################
-ament_export_include_directories(include)
 ament_export_dependencies(dynamixel_sdk)
-ament_export_dependencies(rclcpp)
-ament_export_libraries(${LIB_NAME})
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_package()

--- a/dynamixel_workbench_toolbox/package.xml
+++ b/dynamixel_workbench_toolbox/package.xml
@@ -21,7 +21,6 @@
   <author email="willson@robotis.com">Will Son</author>
   <author email="ywh@robotis.com">Wonho Yun</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>rclcpp</depend>
   <depend>dynamixel_sdk</depend>
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
* Remove unused rclcpp dependency
* Remove ament_target_dependencies (deprecated in ros2 kilted)
* Switch to target-based modern cmake installation
* Install header files to include/${PROJECT_NAME} to follow [ROS 2 best practices.](https://answers.ros.org/question/397356/)
* Replace usage of ``ament_export_include_directories`` and ``ament_export_libraries`` with  ``ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)``, for target-based installation.