### PR TITLE
Deprecate ament_include_dependency usage in CMakeLists.txt 

### DIFF
--- a/dynamixel_workbench/CHANGELOG.rst
+++ b/dynamixel_workbench/CHANGELOG.rst
@@ -5,20 +5,20 @@ Changelog for package dynamixel_workbench
 2.2.5 (2025-06-04)
 ------------------
 * Remove unused rclcpp dependency
-* Remove ament_target_dependencies (deprecated in ros2 kilted)
-* Contributoers: ijnek
+* Remove ament_target_dependencies (deprecated in ROS 2 kilted)
+* Contributors: ijnek
 
 2.2.4 (2025-03-14)
 ------------------
 * Fixed the issue where the Workbench example was not building on SBC by adding the ARM option.
 * Added the CI for ROS 2 rolling, jazzy and Humble.
-* Contributoers: Wonho Yun
+* Contributors: Wonho Yun
 
 2.2.3 (2022-10-06)
 ------------------
 * ROS2 release (Foxy, Galactic, Humble)
 * fix variable length warning (#364)
-* Contributoers: Kenji Brameld, Will Son
+* Contributors: Kenji Brameld, Will Son
 
 2.2.2 (2022-01-25)
 ------------------

--- a/dynamixel_workbench/CHANGELOG.rst
+++ b/dynamixel_workbench/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package dynamixel_workbench
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.5 (2025-06-04)
+------------------
+* Remove unused rclcpp dependency
+* Remove ament_target_dependencies (deprecated in ros2 kilted)
+* Contributoers: ijnek
+
 2.2.4 (2025-03-14)
 ------------------
 * Fixed the issue where the Workbench example was not building on SBC by adding the ARM option.

--- a/dynamixel_workbench/package.xml
+++ b/dynamixel_workbench/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_workbench</name>
-  <version>2.2.4</version>
+  <version>2.2.5</version>
   <description>
     Dynamixel-Workbench is dynamixel solution for ROS.
     This metapackage allows you to easily change the ID, baudrate and operating mode of the Dynamixel.

--- a/dynamixel_workbench_toolbox/CHANGELOG.rst
+++ b/dynamixel_workbench_toolbox/CHANGELOG.rst
@@ -5,20 +5,20 @@ Changelog for package dynamixel_workbench_toolbox
 2.2.5 (2025-06-04)
 ------------------
 * Remove unused rclcpp dependency
-* Remove ament_target_dependencies (deprecated in ros2 kilted)
-* Contributoers: ijnek
+* Remove ament_target_dependencies (deprecated in ROS 2 kilted)
+* Contributors: ijnek
 
 2.2.4 (2025-03-14)
 ------------------
 * Fixed the issue where the Workbench example was not building on SBC by adding the ARM option.
 * Added the CI for ROS 2 rolling, jazzy and Humble.
-* Contributoers: Wonho Yun
+* Contributors: Wonho Yun
 
 2.2.3 (2022-10-06)
 ------------------
 * ROS2 release (Foxy, Galactic, Humble)
 * fix variable length warning (#364)
-* Contributoers: Kenji Brameld, Will Son
+* Contributors: Kenji Brameld, Will Son
 
 2.2.2 (2022-01-25)
 ------------------

--- a/dynamixel_workbench_toolbox/CHANGELOG.rst
+++ b/dynamixel_workbench_toolbox/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package dynamixel_workbench_toolbox
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.5 (2025-06-04)
+------------------
+* Remove unused rclcpp dependency
+* Remove ament_target_dependencies (deprecated in ros2 kilted)
+* Contributoers: ijnek
+
 2.2.4 (2025-03-14)
 ------------------
 * Fixed the issue where the Workbench example was not building on SBC by adding the ARM option.

--- a/dynamixel_workbench_toolbox/CMakeLists.txt
+++ b/dynamixel_workbench_toolbox/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 ################################################################################
 find_package(ament_cmake REQUIRED)
 find_package(dynamixel_sdk REQUIRED)
-find_package(rclcpp REQUIRED)
 
 ################################################################################
 # Declare ROS messages, services and actions
@@ -32,14 +31,6 @@ find_package(rclcpp REQUIRED)
 ################################################################################
 # Build
 ################################################################################
-include_directories(
-  include
-)
-
-set(dependencies_lib
-  "dynamixel_sdk"
-  "rclcpp"
-)
 
 set(LIB_NAME "dynamixel_workbench_toolbox")
 
@@ -49,19 +40,28 @@ add_library(${LIB_NAME} SHARED
   src/${PROJECT_NAME}/dynamixel_tool.cpp
   src/${PROJECT_NAME}/dynamixel_workbench.cpp
 )
-ament_target_dependencies(${LIB_NAME} ${dependencies_lib})
+target_include_directories(${LIB_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  ${dynamixel_sdk_INCLUDE_DIRS}
+)
+
+target_link_libraries(${LIB_NAME} PUBLIC
+  ${dynamixel_sdk_LIBRARIES}
+)
 
 ################################################################################
 # Install
 ################################################################################
 install(TARGETS ${LIB_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin/${PROJECT_NAME}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 ################################################################################
@@ -71,8 +71,6 @@ install(DIRECTORY include/
 ################################################################################
 # Macro for ament package
 ################################################################################
-ament_export_include_directories(include)
 ament_export_dependencies(dynamixel_sdk)
-ament_export_dependencies(rclcpp)
-ament_export_libraries(${LIB_NAME})
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_package()

--- a/dynamixel_workbench_toolbox/library.properties
+++ b/dynamixel_workbench_toolbox/library.properties
@@ -1,7 +1,7 @@
 name=DynamixelWorkbench
-version=2.2.4
+version=2.2.5
 author=Darby Lim (thlim@robotis.com)
-maintainer=Will Son (willson@robotis.com)
+maintainer=Pyo (pyo@robotis.com)
 sentence=DynamixelWorkbench using DynamixelSDK
 paragraph=Tools for Dynamixel
 category=Other

--- a/dynamixel_workbench_toolbox/package.xml
+++ b/dynamixel_workbench_toolbox/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_workbench_toolbox</name>
-  <version>2.2.4</version>
+  <version>2.2.5</version>
   <description>
     This package is composed of 'dynamixel_item', 'dynamixel_tool', 'dynamixel_driver' and 'dynamixel_workbench' class.
     The 'dynamixel_item' is saved as control table item and information of DYNAMIXEL.

--- a/dynamixel_workbench_toolbox/package.xml
+++ b/dynamixel_workbench_toolbox/package.xml
@@ -21,7 +21,6 @@
   <author email="willson@robotis.com">Will Son</author>
   <author email="ywh@robotis.com">Wonho Yun</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>rclcpp</depend>
   <depend>dynamixel_sdk</depend>
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
* Remove unused rclcpp dependency
* Remove ament_target_dependencies (deprecated in ros2 kilted)
* Switch to target-based modern cmake installation
* Install header files to include/${PROJECT_NAME} to follow [ROS 2 best practices.](https://answers.ros.org/question/397356/)
* Replace usage of ament_export_include_directories and ament_export_libraries with ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET), for target-based installation

link : https://github.com/ROBOTIS-GIT/dynamixel-workbench/pull/397
* Contributors: @ijnek 
