### PR TITLE
Check the port handler is non nullptr before trying to close it

### DIFF
--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -19,8 +19,9 @@
 #include <memory>
 #include "../../include/dynamixel_workbench_toolbox/dynamixel_driver.h"
 
-DynamixelDriver::DynamixelDriver() : tools_cnt_(0),
-                                    sync_write_handler_cnt_(0),
+DynamixelDriver::DynamixelDriver() : portHandler_(NULL),
+                                    tools_cnt_(0), 
+                                    sync_write_handler_cnt_(0), 
                                     sync_read_handler_cnt_(0),
                                     bulk_read_parameter_cnt_(0)
 {
@@ -37,7 +38,7 @@ DynamixelDriver::~DynamixelDriver()
     }
   }
 
-  if (portHandler_ != nullptr)
+  if (portHandler_ != NULL)
   {
     portHandler_->closePort();
   }

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -37,7 +37,10 @@ DynamixelDriver::~DynamixelDriver()
     }
   }
 
-  portHandler_->closePort();
+  if (portHandler_ != nullptr)
+  {
+    portHandler_->closePort();
+  }
 }
 
 void DynamixelDriver::initTools(void)


### PR DESCRIPTION
Fixes #404 by first validating the port_handler_ is not null.
I haven't looked at the sdk code so i'm going to assume that we don't need to free this pointer, but its unclear whether this is needed or not from the headers.