### PR TITLE
Fix log message for groupSyncRead addparam failure

### DIFF
--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -1134,7 +1134,7 @@ bool DynamixelDriver::syncRead(uint8_t index, uint8_t *id, uint8_t id_num, const
     sdk_error.dxl_addparam_result = syncReadHandler_[index].groupSyncRead->addParam(id[i]);
     if (sdk_error.dxl_addparam_result != true)
     {
-      if (log != NULL) *log = "[DynamixelDriver] groupSyncRead addparam failed";
+      if (log != NULL) *log = "groupSyncRead addparam failed";
       return false;
     }
   }
@@ -1350,7 +1350,7 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, uint16_t address, uint16_t le
                                                            length);
   if (sdk_error.dxl_addparam_result != true)
   {
-    if (log != NULL) *log = "grouBulkRead addparam failed";
+    if (log != NULL) *log = "groupBulkRead addparam failed";
     return false;
   }
 
@@ -1388,7 +1388,7 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, const char *item_name, const 
                                                           control_item->data_length);
   if (sdk_error.dxl_addparam_result != true)
   {
-    if (log != NULL) *log = "grouBulkRead addparam failed";
+    if (log != NULL) *log = "group BulkRead addparam failed";
     return false;
   }
 

--- a/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/dynamixel_workbench_toolbox/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -1134,7 +1134,7 @@ bool DynamixelDriver::syncRead(uint8_t index, uint8_t *id, uint8_t id_num, const
     sdk_error.dxl_addparam_result = syncReadHandler_[index].groupSyncRead->addParam(id[i]);
     if (sdk_error.dxl_addparam_result != true)
     {
-      if (log != NULL) *log = "groupSyncWrite addparam failed";
+      if (log != NULL) *log = "[DynamixelDriver] groupSyncRead addparam failed";
       return false;
     }
   }


### PR DESCRIPTION
In the current implementation of syncRead, if addParam fails, the error string assigned to *log identifies the failure as originating from groupSyncWrite. This is misleading during runtime debugging, as it points the developer toward the wrong communication handler. 

edit 1 - Corrected the misspelling grouBulkRead to groupBulkRead